### PR TITLE
docs: Fixes broken link to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For more idiomatic Kotlin code we've added `toList` and `toArray` methods in thi
 
 ## Examples
 
-For more, check out [examples](https://github.com/JetBrains/kotlin-spark-api/tree/master/examples/src/main/kotlin/org/jetbrains/spark/api/examples) module.
+For more, check out [examples](https://github.com/JetBrains/kotlin-spark-api/tree/master/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples) module.
 To get up and running quickly, check out this [tutorial](https://github.com/JetBrains/kotlin-spark-api/wiki/Quick-Start-Guide). 
 
 ## Reporting issues/Support


### PR DESCRIPTION
Link to examples lead to 404. This changes points the link to the existing examples module.