### PR TITLE
Add UDFRegister functions for Spark 2.4

### DIFF
--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/Conversions.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/Conversions.kt
@@ -1,0 +1,134 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package org.jetbrains.kotlinx.spark.api
+
+import scala.collection.JavaConversions
+import java.util.concurrent.ConcurrentMap
+import java.util.Enumeration
+import java.util.Dictionary
+import java.util.Properties
+import scala.collection.Iterator as ScalaIterator
+import scala.collection.concurrent.Map as ScalaConcurrentMap
+import scala.collection.mutable.Map as ScalaMutableMap
+import scala.collection.mutable.Set as ScalaMutableSet
+import scala.collection.Iterable as ScalaIterable
+import scala.collection.mutable.Buffer as ScalaMutableBuffer
+import scala.collection.Seq as ScalaSequence
+import scala.collection.Set as ScalaSet
+import scala.collection.mutable.Seq as ScalaMutableSequence
+import scala.collection.Map as ScalaMap
+
+/**
+ * @see JavaConversions.asScalaIterator for more information.
+ */
+inline fun <A> Iterator<A>.asScalaIterator():ScalaIterator<A> = JavaConversions.asScalaIterator(this)
+
+/**
+ * @see JavaConversions.enumerationAsScalaIterator for more information.
+ */
+inline fun <A> Enumeration<A>.asScalaIterator():ScalaIterator<A> = JavaConversions.enumerationAsScalaIterator(this)
+
+/**
+ * @see JavaConversions.iterableAsScalaIterable for more information.
+ */
+inline fun <A> Iterable<A>.asScalaIterable():ScalaIterable<A> = JavaConversions.iterableAsScalaIterable(this)
+
+/**
+ * @see JavaConversions.collectionAsScalaIterable for more information.
+ */
+inline fun <A> Collection<A>.asScalaIterable():ScalaIterable<A> = JavaConversions.collectionAsScalaIterable(this)
+
+/**
+ * @see JavaConversions.asScalaBuffer for more information.
+ */
+inline fun <A> MutableList<A>.asScalaMutableBuffer():ScalaMutableBuffer<A> = JavaConversions.asScalaBuffer(this)
+
+/**
+ * @see JavaConversions.asScalaSet for more information.
+ */
+inline fun <A> MutableSet<A>.asScalaMutableSet():ScalaMutableSet<A> = JavaConversions.asScalaSet(this)
+
+/**
+ * @see JavaConversions.mapAsScalaMap for more information.
+ */
+inline fun <A, B> MutableMap<A, B>.asScalaMutableMap():ScalaMutableMap<A, B> = JavaConversions.mapAsScalaMap(this)
+
+/**
+ * @see JavaConversions.mapAsScalaConcurrentMap for more information.
+ */
+inline fun <A, B> ConcurrentMap<A, B>.asScalaConcurrentMap():ScalaConcurrentMap<A, B> = JavaConversions.mapAsScalaConcurrentMap(this)
+
+/**
+ * @see JavaConversions.dictionaryAsScalaMap for more information.
+ */
+inline fun <A, B> Dictionary<A, B>.asScalaMap():ScalaMutableMap<A, B> = JavaConversions.dictionaryAsScalaMap(this)
+
+/**
+ * @see JavaConversions.propertiesAsScalaMap for more information.
+ */
+inline fun Properties.asScalaMap():ScalaMutableMap<String, String> = JavaConversions.propertiesAsScalaMap(this)
+
+/**
+ * @see JavaConversions.asJavaIterator for more information.
+ */
+inline fun <A> ScalaIterator<A>.asIterator():Iterator<A> = JavaConversions.asJavaIterator(this)
+
+/**
+ * @see JavaConversions.asJavaEnumeration for more information.
+ */
+inline fun <A> ScalaIterator<A>.asEnumeration(): Enumeration<A> = JavaConversions.asJavaEnumeration(this)
+
+/**
+ * @see JavaConversions.asJavaIterable for more information.
+ */
+inline fun <A> ScalaIterable<A>.asIterable():Iterable<A> = JavaConversions.asJavaIterable(this)
+
+/**
+ * @see JavaConversions.asJavaCollection for more information.
+ */
+inline fun <A> ScalaIterable<A>.asCollection():Collection<A> = JavaConversions.asJavaCollection(this)
+
+/**
+ * @see JavaConversions.bufferAsJavaList for more information.
+ */
+inline fun <A> ScalaMutableBuffer<A>.asMutableList():MutableList<A> = JavaConversions.bufferAsJavaList(this)
+
+/**
+ * @see JavaConversions.mutableSeqAsJavaList for more information.
+ */
+inline fun <A> ScalaMutableSequence<A>.asMutableList():MutableList<A> = JavaConversions.mutableSeqAsJavaList(this)
+
+/**
+ * @see JavaConversions.seqAsJavaList for more information.
+ */
+inline fun <A> ScalaSequence<A>.asList():List<A> = JavaConversions.seqAsJavaList(this)
+
+/**
+ * @see JavaConversions.mutableSetAsJavaSet for more information.
+ */
+inline fun <A> ScalaMutableSet<A>.asMutableSet():MutableSet<A> = JavaConversions.mutableSetAsJavaSet(this)
+
+/**
+ * @see JavaConversions.setAsJavaSet for more information.
+ */
+inline fun <A> ScalaSet<A>.asSet():Set<A> = JavaConversions.setAsJavaSet(this)
+
+/**
+ * @see JavaConversions.mutableMapAsJavaMap for more information.
+ */
+inline fun <A, B> ScalaMutableMap<A, B>.asMutableMap():MutableMap<A, B> = JavaConversions.mutableMapAsJavaMap(this)
+
+/**
+ * @see JavaConversions.asJavaDictionary for more information.
+ */
+inline fun <A, B> ScalaMutableMap<A, B>.asDictionary(): Dictionary<A, B> = JavaConversions.asJavaDictionary(this)
+
+/**
+ * @see JavaConversions.mapAsJavaMap for more information.
+ */
+inline fun <A, B> ScalaMap<A, B>.asMap():Map<A, B> = JavaConversions.mapAsJavaMap(this)
+
+/**
+ * @see JavaConversions.mapAsJavaConcurrentMap for more information.
+ */
+inline fun <A, B> ScalaConcurrentMap<A, B>.asConcurrentMap(): ConcurrentMap<A, B> = JavaConversions.mapAsJavaConcurrentMap(this)

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/Functions.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/Functions.kt
@@ -1,0 +1,214 @@
+@file:Suppress("FunctionName", "PackageDirectoryMismatch")
+
+package scala
+
+import scala.runtime.*
+
+/**
+ * Hides the functional interface [scala.Function0]
+ * @see scala.Function0
+ */
+inline fun <R> Function0(crossinline block: ()->R): Function0<R> =
+        object : AbstractFunction0<R>() {
+            override fun apply(): R = block()
+        }
+
+/**
+ * Hides the functional interface [scala.Function1]
+ * @see scala.Function1
+ */
+inline fun <T0, R> Function1(crossinline block: (T0)->R): Function1<T0, R> =
+        object : AbstractFunction1<T0, R>() {
+            override fun apply(p0: T0): R = block(p0)
+        }
+
+/**
+ * Hides the functional interface [scala.Function2]
+ * @see scala.Function2
+ */
+inline fun <T0, T1, R> Function2(crossinline block: (T0, T1)->R): Function2<T0, T1, R> =
+        object : AbstractFunction2<T0, T1, R>() {
+            override fun apply(p0: T0, p1: T1): R = block(p0, p1)
+        }
+
+/**
+ * Hides the functional interface [scala.Function3]
+ * @see scala.Function3
+ */
+inline fun <T0, T1, T2, R> Function3(crossinline block: (T0, T1, T2)->R): Function3<T0, T1, T2, R> =
+        object : AbstractFunction3<T0, T1, T2, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2): R = block(p0, p1, p2)
+        }
+
+/**
+ * Hides the functional interface [scala.Function4]
+ * @see scala.Function4
+ */
+inline fun <T0, T1, T2, T3, R> Function4(crossinline block: (T0, T1, T2, T3)->R): Function4<T0, T1, T2, T3, R> =
+        object : AbstractFunction4<T0, T1, T2, T3, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3): R = block(p0, p1, p2, p3)
+        }
+
+/**
+ * Hides the functional interface [scala.Function5]
+ * @see scala.Function5
+ */
+inline fun <T0, T1, T2, T3, T4, R> Function5(crossinline block: (T0, T1, T2, T3, T4)->R): Function5<T0, T1, T2, T3, T4, R> =
+        object : AbstractFunction5<T0, T1, T2, T3, T4, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4): R = block(p0, p1, p2, p3, p4)
+        }
+
+/**
+ * Hides the functional interface [scala.Function6]
+ * @see scala.Function6
+ */
+inline fun <T0, T1, T2, T3, T4, T5, R> Function6(crossinline block: (T0, T1, T2, T3, T4, T5)->R): Function6<T0, T1, T2, T3, T4, T5, R> =
+        object : AbstractFunction6<T0, T1, T2, T3, T4, T5, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5): R = block(p0, p1, p2, p3, p4, p5)
+        }
+
+/**
+ * Hides the functional interface [scala.Function7]
+ * @see scala.Function7
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, R> Function7(crossinline block: (T0, T1, T2, T3, T4, T5, T6)->R): Function7<T0, T1, T2, T3, T4, T5, T6, R> =
+        object : AbstractFunction7<T0, T1, T2, T3, T4, T5, T6, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6): R = block(p0, p1, p2, p3, p4, p5, p6)
+        }
+
+/**
+ * Hides the functional interface [scala.Function8]
+ * @see scala.Function8
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, R> Function8(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7)->R): Function8<T0, T1, T2, T3, T4, T5, T6, T7, R> =
+        object : AbstractFunction8<T0, T1, T2, T3, T4, T5, T6, T7, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7): R = block(p0, p1, p2, p3, p4, p5, p6, p7)
+        }
+
+/**
+ * Hides the functional interface [scala.Function9]
+ * @see scala.Function9
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, R> Function9(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8)->R): Function9<T0, T1, T2, T3, T4, T5, T6, T7, T8, R> =
+        object : AbstractFunction9<T0, T1, T2, T3, T4, T5, T6, T7, T8, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8)
+        }
+
+/**
+ * Hides the functional interface [scala.Function10]
+ * @see scala.Function10
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> Function10(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)->R): Function10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> =
+        object : AbstractFunction10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+        }
+
+/**
+ * Hides the functional interface [scala.Function11]
+ * @see scala.Function11
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> Function11(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)->R): Function11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> =
+        object : AbstractFunction11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+        }
+
+/**
+ * Hides the functional interface [scala.Function12]
+ * @see scala.Function12
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R> Function12(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)->R): Function12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R> =
+        object : AbstractFunction12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+        }
+
+/**
+ * Hides the functional interface [scala.Function13]
+ * @see scala.Function13
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> Function13(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)->R): Function13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R> =
+        object : AbstractFunction13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
+        }
+
+/**
+ * Hides the functional interface [scala.Function14]
+ * @see scala.Function14
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R> Function14(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)->R): Function14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R> =
+        object : AbstractFunction14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+        }
+
+/**
+ * Hides the functional interface [scala.Function15]
+ * @see scala.Function15
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R> Function15(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)->R): Function15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R> =
+        object : AbstractFunction15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+        }
+
+/**
+ * Hides the functional interface [scala.Function16]
+ * @see scala.Function16
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R> Function16(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)->R): Function16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R> =
+        object : AbstractFunction16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14, p15: T15): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
+        }
+
+/**
+ * Hides the functional interface [scala.Function17]
+ * @see scala.Function17
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R> Function17(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)->R): Function17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R> =
+        object : AbstractFunction17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14, p15: T15, p16: T16): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
+        }
+
+/**
+ * Hides the functional interface [scala.Function18]
+ * @see scala.Function18
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R> Function18(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)->R): Function18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R> =
+        object : AbstractFunction18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14, p15: T15, p16: T16, p17: T17): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
+        }
+
+/**
+ * Hides the functional interface [scala.Function19]
+ * @see scala.Function19
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R> Function19(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)->R): Function19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R> =
+        object : AbstractFunction19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14, p15: T15, p16: T16, p17: T17, p18: T18): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
+        }
+
+/**
+ * Hides the functional interface [scala.Function20]
+ * @see scala.Function20
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R> Function20(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)->R): Function20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R> =
+        object : AbstractFunction20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14, p15: T15, p16: T16, p17: T17, p18: T18, p19: T19): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
+        }
+
+/**
+ * Hides the functional interface [scala.Function21]
+ * @see scala.Function21
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R> Function21(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)->R): Function21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R> =
+        object : AbstractFunction21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14, p15: T15, p16: T16, p17: T17, p18: T18, p19: T19, p20: T20): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
+        }
+
+/**
+ * Hides the functional interface [scala.Function22]
+ * @see scala.Function22
+ */
+inline fun <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R> Function22(crossinline block: (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)->R): Function22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R> =
+        object : AbstractFunction22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R>() {
+            override fun apply(p0: T0, p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, p8: T8, p9: T9, p10: T10, p11: T11, p12: T12, p13: T13, p14: T14, p15: T15, p16: T16, p17: T17, p18: T18, p19: T19, p20: T20, p21: T21): R = block(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
+        }
+
+

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/UDFRegister.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/UDFRegister.kt
@@ -1,0 +1,826 @@
+@file:Suppress("NOTHING_TO_INLINE", "DuplicatedCode", "MemberVisibilityCanBePrivate")
+
+package org.jetbrains.kotlinx.spark.api
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.UDFRegistration
+import org.apache.spark.sql.api.java.*
+import org.apache.spark.sql.functions
+import org.apache.spark.sql.types.DataType
+import scala.collection.mutable.WrappedArray
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.typeOf
+
+/**
+ * A shortcut for [KSparkSession.spark].udf()
+ */
+inline fun KSparkSession.udf(): UDFRegistration = spark.udf()
+
+/**
+ * Checks if [this] is of a valid type for an UDF, otherwise it throws a [TypeOfUDFParameterNotSupportedException]
+ */
+@PublishedApi
+internal fun KClass<*>.checkForValidType(parameterName: String){
+    if (this == String::class || isSubclassOf(WrappedArray::class)) return // Most of the time we need strings or WrappedArrays
+    if (isSubclassOf(Iterable::class) || java.isArray
+            || isSubclassOf(Map::class) || isSubclassOf(Array::class)
+            || isSubclassOf(ByteArray::class) || isSubclassOf(CharArray::class)
+            || isSubclassOf(ShortArray::class) || isSubclassOf(IntArray::class)
+            || isSubclassOf(LongArray::class) || isSubclassOf(FloatArray::class)
+            || isSubclassOf(DoubleArray::class) || isSubclassOf(BooleanArray::class)
+    ){
+        throw TypeOfUDFParameterNotSupportedException(this, parameterName)
+    }
+}
+
+/**
+ * An exception thrown when the UDF is generated with illegal types for the parameters
+ */
+class TypeOfUDFParameterNotSupportedException(kClass: KClass<*>, parameterName: String): IllegalArgumentException(
+        "Parameter $parameterName is subclass of ${kClass.qualifiedName}. If you need to process an array use ${WrappedArray::class.qualifiedName}."
+)
+
+/**
+ * A wrapper for an UDF with 0 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper0(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(): Column {
+        return functions.callUDF(udfName)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF0<R>): UDFWrapper0 {
+    register(name, func, returnType)
+    return UDFWrapper0(name)
+}
+
+/**
+ * A wrapper for an UDF with 1 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper1(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column): Column {
+        return functions.callUDF(udfName, param0)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF1<T0, R>): UDFWrapper1 {
+    T0::class.checkForValidType("T0")
+    register(name, func, returnType)
+    return UDFWrapper1(name)
+}
+
+/**
+ * A wrapper for an UDF with 2 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper2(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column): Column {
+        return functions.callUDF(udfName, param0, param1)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF2<T0, T1, R>): UDFWrapper2 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    register(name, func, returnType)
+    return UDFWrapper2(name)
+}
+
+/**
+ * A wrapper for an UDF with 3 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper3(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF3<T0, T1, T2, R>): UDFWrapper3 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    register(name, func, returnType)
+    return UDFWrapper3(name)
+}
+
+/**
+ * A wrapper for an UDF with 4 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper4(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF4<T0, T1, T2, T3, R>): UDFWrapper4 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    register(name, func, returnType)
+    return UDFWrapper4(name)
+}
+
+/**
+ * A wrapper for an UDF with 5 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper5(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF5<T0, T1, T2, T3, T4, R>): UDFWrapper5 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    register(name, func, returnType)
+    return UDFWrapper5(name)
+}
+
+/**
+ * A wrapper for an UDF with 6 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper6(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF6<T0, T1, T2, T3, T4, T5, R>): UDFWrapper6 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    register(name, func, returnType)
+    return UDFWrapper6(name)
+}
+
+/**
+ * A wrapper for an UDF with 7 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper7(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF7<T0, T1, T2, T3, T4, T5, T6, R>): UDFWrapper7 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    register(name, func, returnType)
+    return UDFWrapper7(name)
+}
+
+/**
+ * A wrapper for an UDF with 8 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper8(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF8<T0, T1, T2, T3, T4, T5, T6, T7, R>): UDFWrapper8 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    register(name, func, returnType)
+    return UDFWrapper8(name)
+}
+
+/**
+ * A wrapper for an UDF with 9 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper9(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF9<T0, T1, T2, T3, T4, T5, T6, T7, T8, R>): UDFWrapper9 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    register(name, func, returnType)
+    return UDFWrapper9(name)
+}
+
+/**
+ * A wrapper for an UDF with 10 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper10(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R>): UDFWrapper10 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    register(name, func, returnType)
+    return UDFWrapper10(name)
+}
+
+/**
+ * A wrapper for an UDF with 11 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper11(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R>): UDFWrapper11 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    register(name, func, returnType)
+    return UDFWrapper11(name)
+}
+
+/**
+ * A wrapper for an UDF with 12 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper12(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R>): UDFWrapper12 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    register(name, func, returnType)
+    return UDFWrapper12(name)
+}
+
+/**
+ * A wrapper for an UDF with 13 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper13(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R>): UDFWrapper13 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    register(name, func, returnType)
+    return UDFWrapper13(name)
+}
+
+/**
+ * A wrapper for an UDF with 14 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper14(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R>): UDFWrapper14 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    register(name, func, returnType)
+    return UDFWrapper14(name)
+}
+
+/**
+ * A wrapper for an UDF with 15 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper15(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R>): UDFWrapper15 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    register(name, func, returnType)
+    return UDFWrapper15(name)
+}
+
+/**
+ * A wrapper for an UDF with 16 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper16(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column, param15: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14, param15)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R>): UDFWrapper16 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    T15::class.checkForValidType("T15")
+    register(name, func, returnType)
+    return UDFWrapper16(name)
+}
+
+/**
+ * A wrapper for an UDF with 17 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper17(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column, param15: Column, param16: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14, param15, param16)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R>): UDFWrapper17 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    T15::class.checkForValidType("T15")
+    T16::class.checkForValidType("T16")
+    register(name, func, returnType)
+    return UDFWrapper17(name)
+}
+
+/**
+ * A wrapper for an UDF with 18 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper18(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column, param15: Column, param16: Column, param17: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14, param15, param16, param17)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R>): UDFWrapper18 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    T15::class.checkForValidType("T15")
+    T16::class.checkForValidType("T16")
+    T17::class.checkForValidType("T17")
+    register(name, func, returnType)
+    return UDFWrapper18(name)
+}
+
+/**
+ * A wrapper for an UDF with 19 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper19(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column, param15: Column, param16: Column, param17: Column, param18: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14, param15, param16, param17, param18)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R>): UDFWrapper19 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    T15::class.checkForValidType("T15")
+    T16::class.checkForValidType("T16")
+    T17::class.checkForValidType("T17")
+    T18::class.checkForValidType("T18")
+    register(name, func, returnType)
+    return UDFWrapper19(name)
+}
+
+/**
+ * A wrapper for an UDF with 20 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper20(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column, param15: Column, param16: Column, param17: Column, param18: Column, param19: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14, param15, param16, param17, param18, param19)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R>): UDFWrapper20 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    T15::class.checkForValidType("T15")
+    T16::class.checkForValidType("T16")
+    T17::class.checkForValidType("T17")
+    T18::class.checkForValidType("T18")
+    T19::class.checkForValidType("T19")
+    register(name, func, returnType)
+    return UDFWrapper20(name)
+}
+
+/**
+ * A wrapper for an UDF with 21 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper21(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column, param15: Column, param16: Column, param17: Column, param18: Column, param19: Column, param20: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14, param15, param16, param17, param18, param19, param20)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R>): UDFWrapper21 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    T15::class.checkForValidType("T15")
+    T16::class.checkForValidType("T16")
+    T17::class.checkForValidType("T17")
+    T18::class.checkForValidType("T18")
+    T19::class.checkForValidType("T19")
+    T20::class.checkForValidType("T20")
+    register(name, func, returnType)
+    return UDFWrapper21(name)
+}
+
+/**
+ * A wrapper for an UDF with 22 arguments.
+ * @property udfName the name of the UDF
+ * @property returnType the return type of the UDF
+ */
+class UDFWrapper22(val udfName: String) {
+    /**
+     * Calls the [functions.callUDF] for the UDF with the [udfName] and the given columns.
+     */
+    operator fun invoke(param0: Column, param1: Column, param2: Column, param3: Column, param4: Column, param5: Column, param6: Column, param7: Column, param8: Column, param9: Column, param10: Column, param11: Column, param12: Column, param13: Column, param14: Column, param15: Column, param16: Column, param17: Column, param18: Column, param19: Column, param20: Column, param21: Column): Column {
+        return functions.callUDF(udfName, param0, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, param11, param12, param13, param14, param15, param16, param17, param18, param19, param20, param21)
+    }
+}
+
+/**
+ * Registers the [func] with its [name] and [returnType] in [this]
+ */
+@OptIn(ExperimentalStdlibApi::class)
+inline fun <reified T0, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified R> UDFRegistration.register(name: String, returnType: DataType = schema(typeOf<R>()), func:UDF22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R>): UDFWrapper22 {
+    T0::class.checkForValidType("T0")
+    T1::class.checkForValidType("T1")
+    T2::class.checkForValidType("T2")
+    T3::class.checkForValidType("T3")
+    T4::class.checkForValidType("T4")
+    T5::class.checkForValidType("T5")
+    T6::class.checkForValidType("T6")
+    T7::class.checkForValidType("T7")
+    T8::class.checkForValidType("T8")
+    T9::class.checkForValidType("T9")
+    T10::class.checkForValidType("T10")
+    T11::class.checkForValidType("T11")
+    T12::class.checkForValidType("T12")
+    T13::class.checkForValidType("T13")
+    T14::class.checkForValidType("T14")
+    T15::class.checkForValidType("T15")
+    T16::class.checkForValidType("T16")
+    T17::class.checkForValidType("T17")
+    T18::class.checkForValidType("T18")
+    T19::class.checkForValidType("T19")
+    T20::class.checkForValidType("T20")
+    T21::class.checkForValidType("T21")
+    register(name, func, returnType)
+    return UDFWrapper22(name)
+}
+
+

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ConversionsTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ConversionsTest.kt
@@ -1,0 +1,90 @@
+package org.jetbrains.kotlinx.spark.api
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.assertThrows
+import scala.Function1
+import scala.Tuple2
+import scala.collection.JavaConversions
+import java.lang.UnsupportedOperationException
+import scala.collection.Set as ScalaSet
+import scala.collection.mutable.Set as ScalaMutableSet
+import scala.collection.Map as ScalaMap
+import scala.collection.mutable.Map as ScalaMutableMap
+import scala.collection.concurrent.Map as ScalaConcurrentMap
+import scala.collection.Seq as ScalaSequence
+import scala.collection.mutable.Seq as ScalaMutableSequence
+
+private fun createScalaSet(): ScalaSet<String> = scala.collection.`Set$`.`MODULE$`.newBuilder<String>().apply {
+    `$plus$eq`("a")
+    `$plus$eq`("b")
+    `$plus$eq`("c")
+}.result()
+
+private fun createScalaMutableSet(): ScalaMutableSet<String> = scala.collection.mutable.`HashSet$`.`MODULE$`.empty<String>().apply {
+    `$plus$eq`("a")
+    `$plus$eq`("b")
+    `$plus$eq`("c")
+}
+
+private fun createScalaMap(): ScalaMap<String, String> = scala.collection.`Map$`.`MODULE$`.newBuilder<String, String>().apply {
+    `$plus$eq`(Tuple2("a", "a"))
+    `$plus$eq`(Tuple2("b", "b"))
+    `$plus$eq`(Tuple2("c", "c"))
+}.result() as ScalaMap<String, String>
+
+private fun createScalaMutableMap(): ScalaMutableMap<String, String> = scala.collection.mutable.`HashMap$`.`MODULE$`.empty<String, String>().apply {
+    `$plus$eq`(Tuple2("a", "a"))
+    `$plus$eq`(Tuple2("b", "b"))
+    `$plus$eq`(Tuple2("c", "c"))
+}
+
+private fun createScalaConcurrentMap(): ScalaConcurrentMap<String, String> = scala.collection.concurrent.`TrieMap$`.`MODULE$`.empty<String, String>().apply {
+    `$plus$eq`(Tuple2("a", "a"))
+    `$plus$eq`(Tuple2("b", "b"))
+    `$plus$eq`(Tuple2("c", "c"))
+}
+
+private fun countFunc() = Function1<String, Any>{ true }
+
+private fun fkt() = Function1<Any, String> {
+    ('A'.toInt()+it as Int).toChar().toString()
+}
+
+private fun createScalaSequence(): ScalaSequence<String> = scala.collection.`Seq$`.`MODULE$`.tabulate<String>(3, fkt()) as ScalaSequence<String>
+
+private fun createScalaMutableSequence(): ScalaMutableSequence<String> = scala.collection.mutable.`Seq$`.`MODULE$`.tabulate<String>(3, fkt()) as ScalaMutableSequence<String>
+
+class ConversionsTest : ShouldSpec({
+    context("org.jetbrains.kotlinx.spark.api.Conversions"){
+        context("Behaviour test for underlying library"){
+            should("Not change when using immutable conversion"){
+                val original: ScalaSet<String> = createScalaSet()
+                val javaSet = JavaConversions.setAsJavaSet(original)
+                assertThrows<UnsupportedOperationException> { javaSet.add("d") }
+                original.size().shouldBe(3)
+            }
+
+            should("Change when using mutable conversion"){
+                val original: ScalaMutableSet<String> = createScalaMutableSet()
+                val javaSet: MutableSet<String> = JavaConversions.mutableSetAsJavaSet(original)
+                javaSet.add("d")
+                original.size().shouldBe(4)
+            }
+        }
+        context("Scala -> Java"){
+            context("Immutable"){
+                should("Sequence should not change"){
+                    val seq: ScalaSequence<String> = createScalaSequence()
+                    val list = seq.asList()
+                    list.size.shouldBe(3)
+                    seq.count(Function1<String, Any>{ true }).shouldBe(3)
+                }
+            }
+            context("Mutable"){
+
+            }
+        }
+
+    }
+})

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/UDFRegisterTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/UDFRegisterTest.kt
@@ -1,0 +1,104 @@
+package org.jetbrains.kotlinx.spark.api
+
+import io.kotest.core.spec.style.ShouldSpec
+import org.apache.spark.sql.RowFactory
+import org.apache.spark.sql.types.DataTypes
+import org.junit.jupiter.api.assertThrows
+import scala.collection.JavaConversions
+import scala.collection.JavaConverters
+import scala.collection.mutable.WrappedArray
+
+private fun <T> scala.collection.Iterable<T>.asIterable(): Iterable<T> = JavaConversions.asJavaIterable(this)
+
+class UDFRegisterTest : ShouldSpec({
+    context("org.jetbrains.kotlinx.spark.api.UDFRegister") {
+        context("the function checkForValidType"){
+            val invalidTypes = listOf(
+                    Array::class,
+                    Iterable::class,
+                    List::class,
+                    MutableList::class,
+                    ByteArray::class,
+                    CharArray::class,
+                    ShortArray::class,
+                    IntArray::class,
+                    LongArray::class,
+                    FloatArray::class,
+                    DoubleArray::class,
+                    BooleanArray::class,
+                    Map::class,
+                    MutableMap::class,
+                    Set::class,
+                    MutableSet::class,
+                    arrayOf("")::class,
+                    listOf("")::class,
+                    setOf("")::class,
+                    mapOf("" to "")::class,
+                    mutableListOf("")::class,
+                    mutableSetOf("")::class,
+                    mutableMapOf("" to "")::class,
+            )
+            invalidTypes.forEachIndexed { index, invalidType ->
+                should("$index: throw an ${TypeOfUDFParameterNotSupportedException::class.simpleName} when encountering ${invalidType.qualifiedName}"){
+                    assertThrows<TypeOfUDFParameterNotSupportedException> {
+                        invalidType.checkForValidType("test")
+                    }
+                }
+            }
+        }
+
+        context("the register-function"){
+            withSpark {
+
+                should("fails when using a simple kotlin.Array"){
+                    assertThrows<TypeOfUDFParameterNotSupportedException> {
+                        udf().register("shouldFail", DataTypes.StringType) { array: Array<String> ->
+                            array.joinToString(" ")
+                        }
+                    }
+                }
+
+                should("succeeds when using a WrappedArray"){
+                    udf().register("shouldSucceed", DataTypes.StringType){
+                        array: WrappedArray<String> ->
+                        array.asIterable().joinToString(" ")
+                    }
+                }
+            }
+        }
+
+        context("calling the UDF-Wrapper"){
+            withSpark {
+                val schema  = DataTypes.createStructType(
+                        listOf(
+                                DataTypes.createStructField("textArray", DataTypes.createArrayType(DataTypes.StringType), false),
+                                DataTypes.createStructField("id", DataTypes.StringType, false)
+                        )
+                )
+
+                val rows = listOf(
+                        RowFactory.create(arrayOf("a", "b", "c"), "1"),
+                        RowFactory.create(arrayOf("d", "e", "f"), "2"),
+                        RowFactory.create(arrayOf("g", "h", "i"), "3"),
+                )
+
+                val testData = spark.createDataFrame(rows, schema)
+
+                val stringArrayMerger = udf().register("stringArrayMerger", DataTypes.StringType){
+                    array: WrappedArray<String> ->
+                    array.asIterable().joinToString(" ")
+                }
+
+                should("succeeds when using the right number of arguments"){
+
+                    val newData = testData.withColumn("text", stringArrayMerger(testData.col("textArray")))
+
+                    newData.select("text").collectAsList().zip(newData.select("textArray").collectAsList()).forEach {
+                        (text, textArray) ->
+                        assert(text.getString(0) == textArray.getList<String>(0).joinToString(" "))
+                    }
+                }
+            }
+        }
+    }
+})

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/UDFRegisterTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/UDFRegisterTest.kt
@@ -8,8 +8,6 @@ import scala.collection.JavaConversions
 import scala.collection.JavaConverters
 import scala.collection.mutable.WrappedArray
 
-private fun <T> scala.collection.Iterable<T>.asIterable(): Iterable<T> = JavaConversions.asJavaIterable(this)
-
 class UDFRegisterTest : ShouldSpec({
     context("org.jetbrains.kotlinx.spark.api.UDFRegister") {
         context("the function checkForValidType"){


### PR DESCRIPTION
## Short description
Add a kotlin-styled way to create and call UDFs in a more secure manner.

## Possible improvements
- Add more Unit-Tests?
- Publish generator code for the functions (but i don't know where i should put it)

## Future plans
- Add advanced type-checking before calling a function by comparing the schematas of the function parameters with the column schema?