### PR TITLE
feat: Adds broadcast function

### DIFF
--- a/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples/Broadcasting.kt
+++ b/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples/Broadcasting.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.kotlinx.spark.examples
+
+import org.jetbrains.kotlinx.spark.api.broadcast
+import org.jetbrains.kotlinx.spark.api.map
+import org.jetbrains.kotlinx.spark.api.sparkContext
+import org.jetbrains.kotlinx.spark.api.withSpark
+import java.io.Serializable
+
+// (data) class must be Serializable to be broadcast
+data class SomeClass(val a: IntArray, val b: Int) : Serializable
+
+fun main() = withSpark {
+    val broadcastVariable = spark.sparkContext.broadcast(SomeClass(a = intArrayOf(5, 6), b = 3))
+    val result = listOf(1, 2, 3, 4, 5)
+            .toDS()
+            .map {
+                val receivedBroadcast = broadcastVariable.value
+                it + receivedBroadcast.a.first()
+            }
+            .collectAsList()
+
+    println(result)
+}

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -22,7 +22,6 @@
 package org.jetbrains.kotlinx.spark.api
 
 import org.apache.spark.SparkContext
-import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.api.java.function.*
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.*

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -22,7 +22,9 @@
 package org.jetbrains.kotlinx.spark.api
 
 import org.apache.spark.SparkContext
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.api.java.function.*
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.*
 import org.apache.spark.sql.Encoders.*
 import org.apache.spark.sql.catalyst.JavaTypeInference
@@ -62,6 +64,17 @@ val ENCODERS = mapOf<KClass<*>, Encoder<*>>(
         Timestamp::class to TIMESTAMP(),
         ByteArray::class to BINARY()
 )
+
+/**
+ * Broadcast a read-only variable to the cluster, returning a
+ * [[org.apache.spark.broadcast.Broadcast]] object for reading it in distributed functions.
+ * The variable will be sent to each cluster only once.
+ *
+ * @param value value to broadcast to the Spark nodes
+ * @return `Broadcast` object, a read-only variable cached on each machine
+ */
+inline fun <reified T> SparkContext.broadcast(value: T): Broadcast<T> = broadcast(value, encoder<T>().clsTag())
+
 
 /**
  * Utility method to create dataset from list

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -21,6 +21,7 @@ import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
+import java.io.Serializable
 import java.time.LocalDate
 
 class ApiTest : ShouldSpec({
@@ -149,8 +150,30 @@ class ApiTest : ShouldSpec({
                 expect(result).asExpect().contains.inOrder.only.values(2, 3, 4, 5)
 
             }
+            @OptIn(ExperimentalStdlibApi::class)
+            should("broadcast variables") {
+                val largeList = (1..15).map { SomeClass(a = (it..15).toList().toIntArray(), b = it) }
+                val broadcast = spark.sparkContext.broadcast(largeList)
+
+                val result: List<Int> = listOf(1, 2, 3, 4, 5)
+                        .toDS()
+                        .mapPartitions { iterator ->
+                            val receivedBroadcast = broadcast.value
+                            buildList {
+                                iterator.forEach {
+                                    this.add(it + receivedBroadcast[it].b)
+                                }
+                            }.iterator()
+                        }
+                        .collectAsList()
+
+                expect(result).asExpect().contains.inOrder.only.values(3, 5, 7, 9, 11)
+            }
         }
     }
 })
 
 data class LonLat(val lon: Double, val lat: Double)
+
+// (data) class must be Serializable to be broadcast
+data class SomeClass(val a: IntArray, val b: Int) : Serializable


### PR DESCRIPTION
Added a Kotlin wrapper for the function to broadcast read-only variables to the cluster. It works just as easily as `JavaSparkContext.broadcast()`

Created because of issue: https://github.com/JetBrains/kotlin-spark-api/issues/69