### PR TITLE
Tuple encoding (but also help needed) 

### DIFF
--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types.*
 import org.jetbrains.kotlinx.spark.extensions.KSparkExtensions
+import scala.*
 import scala.collection.Seq
 import scala.reflect.`ClassTag$`
 import java.beans.PropertyDescriptor
@@ -46,6 +47,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
 @JvmField
@@ -109,6 +111,7 @@ inline fun <reified T> encoder(): Encoder<T> = generateEncoder(typeOf<T>(), T::c
 fun <T> generateEncoder(type: KType, cls: KClass<*>): Encoder<T> {
     @Suppress("UNCHECKED_CAST")
     return when {
+        isTuple(cls) -> tupleEncoder(type)
         isSupportedClass(cls) -> kotlinClassEncoder(memoizedSchema(type), cls)
         else -> ENCODERS[cls] as? Encoder<T>? ?: bean(cls.java)
     } as Encoder<T>
@@ -130,6 +133,45 @@ private fun <T> kotlinClassEncoder(schema: DataType, kClass: KClass<*>): Encoder
             if (schema is DataTypeWithClass) KotlinReflection.deserializerFor(kClass.java, schema) else JavaTypeInference.deserializerFor(kClass.java),
             `ClassTag$`.`MODULE$`.apply(kClass.java)
     )
+}
+
+private fun isTuple(cls: KClass<*>): Boolean = listOf(
+    Tuple1::class,
+    Tuple2::class,
+    Tuple3::class,
+    Tuple4::class,
+    Tuple5::class,
+    Tuple6::class,
+    Tuple7::class,
+    Tuple8::class,
+    Tuple9::class,
+    Tuple10::class,
+    Tuple11::class,
+    Tuple12::class,
+    Tuple13::class,
+    Tuple14::class,
+    Tuple15::class,
+    Tuple16::class,
+    Tuple17::class,
+    Tuple18::class,
+    Tuple19::class,
+    Tuple20::class,
+    Tuple21::class,
+    Tuple22::class,
+).any { cls.isSubclassOf(it) }
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> tupleEncoder(type: KType): Encoder<T> {
+    val encoders: List<Encoder<Any>> = type.arguments.map {
+        generateEncoder(it.type!!, it.type!!.jvmErasure)
+    }
+    return when (encoders.size) {
+        2 -> tuple(encoders[0], encoders[1])
+        3 -> tuple(encoders[0], encoders[1], encoders[2])
+        4 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3])
+        5 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3], encoders[4])
+        else -> throw IllegalArgumentException("Cannot encode a tuple with ${encoders.size} arguments at the moment.")
+    } as Encoder<T>
 }
 
 inline fun <reified T, reified R> Dataset<T>.map(noinline func: (T) -> R): Dataset<R> =
@@ -341,6 +383,20 @@ fun schema(type: KType, map: Map<String, KType> = mapOf()): DataType {
                             .toTypedArray()
             )
             KDataTypeWrapper(structType, klass.java, true)
+        }
+        klass.isSubclassOf(Product::class) -> {
+            throw IllegalArgumentException("$type is unsupported")
+            // TODO This should provide a datatype for products such as tuples but it does not work yet
+
+            val structType = DataTypes.createStructType(
+                type.arguments.mapIndexed { i, it ->
+                    val projectedType = it.type!!
+                    val name = "_${i + 1}"
+                    val structField = StructField(name, schema(projectedType, types), projectedType.isMarkedNullable, Metadata.empty())
+                    KStructField(name, structField)
+                }.toTypedArray()
+            )
+            KDataTypeWrapper(structType, klass.java, type.isMarkedNullable)
         }
         else -> throw IllegalArgumentException("$type is unsupported")
     }

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -21,6 +21,9 @@ import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import scala.Tuple2
+import scala.Tuple3
 import java.io.Serializable
 import java.time.LocalDate
 
@@ -156,9 +159,31 @@ class ApiTest : ShouldSpec({
 
                 expect(result).asExpect().contains.inOrder.only.values(3, 5, 7, 9, 11)
             }
+            should("Be able to serialize Scala Tuples including data classes") {
+                val dataset = dsOf(
+                    Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
+                    Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
+            }
+            should("Be able to serialize data classes with tuples") {
+                val dataset = dsOf(
+                    DataClassWithTuple(Tuple2(5L, "test")),
+                    DataClassWithTuple(Tuple2(6L, "tessst")),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first().tuple shouldBe Tuple2(5L, "test")
+            }
         }
     }
 })
+
+data class DataClassWithTuple(val tuple: Tuple2<Long, String>)
 
 data class LonLat(val lon: Double, val lat: Double)
 data class Test<Z>(val id: Long, val data: Array<Pair<Z, Int>>) {

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -29,6 +29,7 @@ import org.apache.spark.sql.Encoders.*
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.types.*
 import org.jetbrains.kotinx.spark.extensions.KSparkExtensions
+import scala.*
 import scala.reflect.ClassTag
 import java.beans.PropertyDescriptor
 import java.math.BigDecimal
@@ -42,6 +43,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
 @JvmField
@@ -104,6 +106,7 @@ inline fun <reified T> encoder(): Encoder<T> = generateEncoder(typeOf<T>(), T::c
 fun <T> generateEncoder(type: KType, cls: KClass<*>): Encoder<T> {
     @Suppress("UNCHECKED_CAST")
     return when {
+        isTuple(cls) -> tupleEncoder(type)
         isSupportedClass(cls) -> kotlinClassEncoder(memoizedSchema(type), cls)
         else -> ENCODERS[cls] as? Encoder<T>? ?: bean(cls.java)
     } as Encoder<T>
@@ -120,6 +123,45 @@ private fun <T> kotlinClassEncoder(schema: DataType, kClass: KClass<*>): Encoder
             if (schema is DataTypeWithClass) KotlinReflection.deserializerFor(kClass.java, schema) else KotlinReflection.deserializerForType(KotlinReflection.getType(kClass.java)),
             ClassTag.apply(kClass.java)
     )
+}
+
+private fun isTuple(cls: KClass<*>): Boolean = listOf(
+    Tuple1::class,
+    Tuple2::class,
+    Tuple3::class,
+    Tuple4::class,
+    Tuple5::class,
+    Tuple6::class,
+    Tuple7::class,
+    Tuple8::class,
+    Tuple9::class,
+    Tuple10::class,
+    Tuple11::class,
+    Tuple12::class,
+    Tuple13::class,
+    Tuple14::class,
+    Tuple15::class,
+    Tuple16::class,
+    Tuple17::class,
+    Tuple18::class,
+    Tuple19::class,
+    Tuple20::class,
+    Tuple21::class,
+    Tuple22::class,
+).any { cls.isSubclassOf(it) }
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> tupleEncoder(type: KType): Encoder<T> {
+    val encoders: List<Encoder<Any>> = type.arguments.map {
+        generateEncoder(it.type!!, it.type!!.jvmErasure)
+    }
+    return when (encoders.size) {
+        2 -> tuple(encoders[0], encoders[1])
+        3 -> tuple(encoders[0], encoders[1], encoders[2])
+        4 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3])
+        5 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3], encoders[4])
+        else -> throw IllegalArgumentException("Cannot encode a tuple with ${encoders.size} arguments at the moment.")
+    } as Encoder<T>
 }
 
 inline fun <reified T, reified R> Dataset<T>.map(noinline func: (T) -> R): Dataset<R> =
@@ -328,6 +370,20 @@ fun schema(type: KType, map: Map<String, KType> = mapOf()): DataType {
                             .toTypedArray()
             )
             KDataTypeWrapper(structType, klass.java, true)
+        }
+        klass.isSubclassOf(Product::class) -> {
+            throw IllegalArgumentException("$type is unsupported")
+            // TODO This should provide a datatype for products such as tuples but it does not work yet
+
+            val structType = DataTypes.createStructType(
+                type.arguments.mapIndexed { i, it ->
+                    val projectedType = it.type!!
+                    val name = "_${i + 1}"
+                    val structField = StructField(name, schema(projectedType, types), projectedType.isMarkedNullable, Metadata.empty())
+                    KStructField(name, structField)
+                }.toTypedArray()
+            )
+            KDataTypeWrapper(structType, klass.java, type.isMarkedNullable)
         }
         else -> throw IllegalArgumentException("$type is unsupported")
     }

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -21,6 +21,9 @@ import ch.tutteli.atrium.api.fluent.en_GB.*
 import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import scala.Tuple2
+import scala.Tuple3
 import java.io.Serializable
 import java.time.LocalDate
 
@@ -169,9 +172,31 @@ class ApiTest : ShouldSpec({
 
                 expect(result).asExpect().contains.inOrder.only.values(3, 5, 7, 9, 11)
             }
+            should("Be able to serialize Scala Tuples including data classes") {
+                val dataset = dsOf(
+                    Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
+                    Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
+            }
+            should("Be able to serialize data classes with tuples") {
+                val dataset = dsOf(
+                    DataClassWithTuple(Tuple2(5L, "test")),
+                    DataClassWithTuple(Tuple2(6L, "tessst")),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first().tuple shouldBe Tuple2(5L, "test")
+            }
         }
     }
 })
+
+data class DataClassWithTuple(val tuple: Tuple2<Long, String>)
 
 data class LonLat(val lon: Double, val lat: Double)
 


### PR DESCRIPTION
This adds the ability to encode all tuples of length 2 until 5 (as provided by the spark encoder functions) using the ```encoder<T>()``` method.
This means you can now create and use
```kotlin
val dataset = dsOf(
    Tuple2("a", Tuple3("a", 1, SomeDataClass(1.0, 1.0))),
    Tuple2("b", Tuple3("b", 2, SomeDataClass(1.0, 2.0))),
)
```
and it will work correctly (Test is included).

What does not yet work and what I will need help for is providing the schema for tuples and other `Product` types.
That would make
```kotlin
val dataset = dsOf(
    SomeDataClass(Tuple2("a", 1)),
    SomeDataClass(Tuple2("b", 4)),
)
```
possible as well. I did try to create a `DataType` for it (at the `TODO` in `ApiV1.kt`) and wrote a test for it, but due to my inexperience with the wrappers and Scala, I'm not able to get it to work currently. 
Any help would be welcome!

Of course, merging the first and skipping the second for now is also an option.