### PR TITLE
Enhancement: Improved broadcasting

### DIFF
--- a/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples/Broadcasting.kt
+++ b/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples/Broadcasting.kt
@@ -29,7 +29,7 @@ import java.io.Serializable
 data class SomeClass(val a: IntArray, val b: Int) : Serializable
 
 fun main() = withSpark {
-    val broadcastVariable = spark.sparkContext.broadcast(SomeClass(a = intArrayOf(5, 6), b = 3))
+    val broadcastVariable = spark.broadcast(SomeClass(a = intArrayOf(5, 6), b = 3))
     val result = listOf(1, 2, 3, 4, 5)
             .toDS()
             .map {

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -22,6 +22,7 @@
 package org.jetbrains.kotlinx.spark.api
 
 import org.apache.spark.SparkContext
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.api.java.function.*
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.*
@@ -72,8 +73,11 @@ val ENCODERS = mapOf<KClass<*>, Encoder<*>>(
  * @param value value to broadcast to the Spark nodes
  * @return `Broadcast` object, a read-only variable cached on each machine
  */
-inline fun <reified T> SparkContext.broadcast(value: T): Broadcast<T> = broadcast(value, encoder<T>().clsTag())
-
+inline fun <reified T> SparkSession.broadcast(value: T): Broadcast<T> = try {
+    sparkContext.broadcast(value, encoder<T>().clsTag())
+} catch (e: ClassNotFoundException) {
+    JavaSparkContext(sparkContext).broadcast(value)
+}
 
 /**
  * Utility method to create dataset from list

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -67,7 +67,7 @@ val ENCODERS = mapOf<KClass<*>, Encoder<*>>(
 
 /**
  * Broadcast a read-only variable to the cluster, returning a
- * [[org.apache.spark.broadcast.Broadcast]] object for reading it in distributed functions.
+ * [org.apache.spark.broadcast.Broadcast] object for reading it in distributed functions.
  * The variable will be sent to each cluster only once.
  *
  * @param value value to broadcast to the Spark nodes
@@ -77,6 +77,22 @@ inline fun <reified T> SparkSession.broadcast(value: T): Broadcast<T> = try {
     sparkContext.broadcast(value, encoder<T>().clsTag())
 } catch (e: ClassNotFoundException) {
     JavaSparkContext(sparkContext).broadcast(value)
+}
+
+/**
+ * Broadcast a read-only variable to the cluster, returning a
+ * [org.apache.spark.broadcast.Broadcast] object for reading it in distributed functions.
+ * The variable will be sent to each cluster only once.
+ *
+ * @param value value to broadcast to the Spark nodes
+ * @return `Broadcast` object, a read-only variable cached on each machine
+ * @see broadcast
+ */
+@Deprecated("You can now use `spark.broadcast()` instead.", ReplaceWith("spark.broadcast(value)"), DeprecationLevel.WARNING)
+inline fun <reified T> SparkContext.broadcast(value: T): Broadcast<T> = try {
+    broadcast(value, encoder<T>().clsTag())
+} catch (e: ClassNotFoundException) {
+    JavaSparkContext(this).broadcast(value)
 }
 
 /**

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -140,21 +140,24 @@ class ApiTest : ShouldSpec({
             @OptIn(ExperimentalStdlibApi::class)
             should("broadcast variables") {
                 val largeList = (1..15).map { SomeClass(a = (it..15).toList().toIntArray(), b = it) }
-                val broadcast = spark.sparkContext.broadcast(largeList)
-                
-                val result: List<Int> = listOf(1, 2, 3, 4, 5)
-                        .toDS()
-                        .mapPartitions { iterator ->
-                            val receivedBroadcast = broadcast.value
-                            buildList {
-                                iterator.forEach {
-                                    this.add(it + receivedBroadcast[it].b)
-                                }
-                            }.iterator()
-                        }
-                        .collectAsList()
+                val broadcast = spark.broadcast(largeList)
+                val broadcast2 = spark.broadcast(arrayOf(doubleArrayOf(1.0, 2.0, 3.0, 4.0)))
 
-                expect(result).asExpect().contains.inOrder.only.values(3, 5, 7, 9, 11)
+                val result: List<Double> = listOf(1, 2, 3, 4, 5)
+                    .toDS()
+                    .mapPartitions { iterator ->
+                        val receivedBroadcast = broadcast.value
+                        val receivedBroadcast2 = broadcast2.value
+
+                        buildList {
+                            iterator.forEach {
+                                this.add(it + receivedBroadcast[it].b * receivedBroadcast2[0][0])
+                            }
+                        }.iterator()
+                    }
+                    .collectAsList()
+
+                expect(result).asExpect().contains.inOrder.only.values(3.0, 5.0, 7.0, 9.0, 11.0)
             }
         }
     }

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -22,6 +22,7 @@
 package org.jetbrains.kotlinx.spark.api
 
 import org.apache.spark.SparkContext
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.api.java.function.*
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.*
@@ -69,7 +70,11 @@ val ENCODERS = mapOf<KClass<*>, Encoder<*>>(
  * @param value value to broadcast to the Spark nodes
  * @return `Broadcast` object, a read-only variable cached on each machine
  */
-inline fun <reified T> SparkContext.broadcast(value: T): Broadcast<T> = broadcast(value, encoder<T>().clsTag())
+inline fun <reified T> SparkSession.broadcast(value: T): Broadcast<T> = try {
+    sparkContext.broadcast(value, encoder<T>().clsTag())
+} catch (e: ClassNotFoundException) {
+    JavaSparkContext(sparkContext).broadcast(value)
+}
 
 /**
  * Utility method to create dataset from list

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -64,7 +64,7 @@ val ENCODERS = mapOf<KClass<*>, Encoder<*>>(
 
 /**
  * Broadcast a read-only variable to the cluster, returning a
- * [[org.apache.spark.broadcast.Broadcast]] object for reading it in distributed functions.
+ * [org.apache.spark.broadcast.Broadcast] object for reading it in distributed functions.
  * The variable will be sent to each cluster only once.
  *
  * @param value value to broadcast to the Spark nodes
@@ -74,6 +74,22 @@ inline fun <reified T> SparkSession.broadcast(value: T): Broadcast<T> = try {
     sparkContext.broadcast(value, encoder<T>().clsTag())
 } catch (e: ClassNotFoundException) {
     JavaSparkContext(sparkContext).broadcast(value)
+}
+
+/**
+ * Broadcast a read-only variable to the cluster, returning a
+ * [org.apache.spark.broadcast.Broadcast] object for reading it in distributed functions.
+ * The variable will be sent to each cluster only once.
+ *
+ * @param value value to broadcast to the Spark nodes
+ * @return `Broadcast` object, a read-only variable cached on each machine
+ * @see broadcast
+ */
+@Deprecated("You can now use `spark.broadcast()` instead.", ReplaceWith("spark.broadcast(value)"), DeprecationLevel.WARNING)
+inline fun <reified T> SparkContext.broadcast(value: T): Broadcast<T> = try {
+    broadcast(value, encoder<T>().clsTag())
+} catch (e: ClassNotFoundException) {
+    JavaSparkContext(this).broadcast(value)
 }
 
 /**

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -153,21 +153,24 @@ class ApiTest : ShouldSpec({
             @OptIn(ExperimentalStdlibApi::class)
             should("broadcast variables") {
                 val largeList = (1..15).map { SomeClass(a = (it..15).toList().toIntArray(), b = it) }
-                val broadcast = spark.sparkContext.broadcast(largeList)
+                val broadcast = spark.broadcast(largeList)
+                val broadcast2 = spark.broadcast(arrayOf(doubleArrayOf(1.0, 2.0, 3.0, 4.0)))
 
-                val result: List<Int> = listOf(1, 2, 3, 4, 5)
+                val result: List<Double> = listOf(1, 2, 3, 4, 5)
                         .toDS()
                         .mapPartitions { iterator ->
                             val receivedBroadcast = broadcast.value
+                            val receivedBroadcast2 = broadcast2.value
+
                             buildList {
                                 iterator.forEach {
-                                    this.add(it + receivedBroadcast[it].b)
+                                    this.add(it + receivedBroadcast[it].b * receivedBroadcast2[0][0])
                                 }
                             }.iterator()
                         }
                         .collectAsList()
 
-                expect(result).asExpect().contains.inOrder.only.values(3, 5, 7, 9, 11)
+                expect(result).asExpect().contains.inOrder.only.values(3.0, 5.0, 7.0, 9.0, 11.0)
             }
         }
     }


### PR DESCRIPTION
Instead of calling 
```kotlin
spark.sparkContext.broadcast(
```
you can now simply call
```kotlin
spark.broadcast(
```
which matches some of the other helper functions in the API.

Aside from that there are a lot of cases where the `encoder<>()` function cannot find the encoder for a certain type like `Array<DoubleArray>` for instance. For these cases I added a fallback on the `JavaSparkContext.broadcast` function already present in Spark. This makes sure that at the `encoder<>()` method is attempted (so broadcasting Data classes still works fine), but if that fails it still has a backup solution.

Tests are included of course.
