### PR TITLE
Adds support for Tuple encoding

### DIFF
--- a/core/3.0/src/main/scala/org/apache/spark/sql/KotlinReflection.scala
+++ b/core/3.0/src/main/scala/org/apache/spark/sql/KotlinReflection.scala
@@ -354,43 +354,6 @@ object KotlinReflection extends KotlinReflection {
           dataType = ObjectType(udt.getClass))
         Invoke(obj, "deserialize", ObjectType(udt.userClass), path :: Nil)
 
-      // TODO new
-      case t if definedByConstructorParams(t) =>
-        val params = getConstructorParameters(t)
-
-        val cls = getClassFromType(tpe)
-
-        val arguments = params.zipWithIndex.map { case ((fieldName, fieldType), i) =>
-          val Schema(dataType, nullable) = schemaFor(fieldType)
-          val clsName = getClassNameFromType(fieldType)
-          val newTypePath = walkedTypePath.recordField(clsName, fieldName)
-
-          // For tuples, we based grab the inner fields by ordinal instead of name.
-          val newPath = if (cls.getName startsWith "scala.Tuple") {
-            deserializerFor(
-              fieldType,
-              addToPathOrdinal(path, i, dataType, newTypePath),
-              newTypePath)
-          } else {
-            deserializerFor(
-              fieldType,
-              addToPath(path, fieldName, dataType, newTypePath),
-              newTypePath)
-          }
-          expressionWithNullSafety(
-            newPath,
-            nullable = nullable,
-            newTypePath)
-        }
-
-        val newInstance = NewInstance(cls, arguments, ObjectType(cls), propagateNull = false)
-
-        org.apache.spark.sql.catalyst.expressions.If(
-          IsNull(path),
-          org.apache.spark.sql.catalyst.expressions.Literal.create(null, ObjectType(cls)),
-          newInstance
-        )
-
       case _ if predefinedDt.isDefined =>
         predefinedDt.get match {
           case wrapper: KDataTypeWrapper =>
@@ -477,11 +440,79 @@ object KotlinReflection extends KotlinReflection {
 
                 UnresolvedMapObjects(mapFunction, path, customCollectionCls = Some(t.cls))
 
+              case StructType(elementType: Array[StructField])  =>
+                val cls = t.cls
+
+                val arguments = elementType.map { field =>
+                    val dataType = field.dataType.asInstanceOf[DataTypeWithClass]
+                    val nullable = dataType.nullable
+                    val clsName = getClassNameFromType(getType(dataType.cls))
+                    val newTypePath = walkedTypePath.recordField(clsName, field.name)
+
+                    // For tuples, we based grab the inner fields by ordinal instead of name.
+                    val newPath = deserializerFor(
+                      getType(dataType.cls),
+                      addToPath(path, field.name, dataType.dt, newTypePath),
+                      newTypePath,
+                      Some(dataType).filter(_.isInstanceOf[ComplexWrapper])
+                    )
+                    expressionWithNullSafety(
+                      newPath,
+                      nullable = nullable,
+                      newTypePath
+                    )
+                  }
+                val newInstance = NewInstance(cls, arguments, ObjectType(cls), propagateNull = false)
+
+                org.apache.spark.sql.catalyst.expressions.If(
+                  IsNull(path),
+                  org.apache.spark.sql.catalyst.expressions.Literal.create(null, ObjectType(cls)),
+                  newInstance
+                )
+
+
               case _ =>
                 throw new UnsupportedOperationException(
                   s"No Encoder found for $tpe\n" + walkedTypePath)
             }
         }
+
+      case t if definedByConstructorParams(t) =>
+        val params = getConstructorParameters(t)
+
+        val cls = getClassFromType(tpe)
+
+        val arguments = params.zipWithIndex.map { case ((fieldName, fieldType), i) =>
+          val Schema(dataType, nullable) = schemaFor(fieldType)
+          val clsName = getClassNameFromType(fieldType)
+          val newTypePath = walkedTypePath.recordField(clsName, fieldName)
+
+          // For tuples, we based grab the inner fields by ordinal instead of name.
+          val newPath = if (cls.getName startsWith "scala.Tuple") {
+            deserializerFor(
+              fieldType,
+              addToPathOrdinal(path, i, dataType, newTypePath),
+              newTypePath)
+          } else {
+            deserializerFor(
+              fieldType,
+              addToPath(path, fieldName, dataType, newTypePath),
+              newTypePath)
+          }
+          expressionWithNullSafety(
+            newPath,
+            nullable = nullable,
+            newTypePath)
+        }
+
+        val newInstance = NewInstance(cls, arguments, ObjectType(cls), propagateNull = false)
+
+        org.apache.spark.sql.catalyst.expressions.If(
+          IsNull(path),
+          org.apache.spark.sql.catalyst.expressions.Literal.create(null, ObjectType(cls)),
+          newInstance
+        )
+
       case _ =>
         throw new UnsupportedOperationException(
           s"No Encoder found for $tpe\n" + walkedTypePath)
@@ -699,32 +730,6 @@ object KotlinReflection extends KotlinReflection {
         createSerializerForUserDefinedType(inputObject, udt, udtClass)
       //</editor-fold>
 
-
-      case t if definedByConstructorParams(t) =>
-        if (seenTypeSet.contains(t)) {
-          throw new UnsupportedOperationException(
-            s"cannot have circular references in class, but got the circular reference of class $t")
-        }
-
-        val params = getConstructorParameters(t)
-        val fields = params.map { case (fieldName, fieldType) =>
-          if (javaKeywords.contains(fieldName)) {
-            throw new UnsupportedOperationException(s"`$fieldName` is a reserved keyword and " +
-              "cannot be used as field name\n" + walkedTypePath)
-          }
-
-          // SPARK-26730 inputObject won't be null with If's guard below. And KnownNotNul
-          // is necessary here. Because for a nullable nested inputObject with struct data
-          // type, e.g. StructType(IntegerType, StringType), it will return nullable=true
-          // for IntegerType without KnownNotNull. And that's what we do not expect to.
-          val fieldValue = Invoke(KnownNotNull(inputObject), fieldName, dataTypeFor(fieldType),
-            returnNullable = !fieldType.typeSymbol.asClass.isPrimitive)
-          val clsName = getClassNameFromType(fieldType)
-          val newPath = walkedTypePath.recordField(clsName, fieldName)
-          (fieldName, serializerFor(fieldValue, fieldType, newPath, seenTypeSet + t))
-        }
-        createSerializerForObject(inputObject, fields)
-
       case _ if predefinedDt.isDefined =>
         predefinedDt.get match {
           case dataType: KDataTypeWrapper =>
@@ -772,12 +777,66 @@ object KotlinReflection extends KotlinReflection {
                 )
               case ArrayType(elementType, _) =>
                 toCatalystArray(inputObject, getType(elementType.asInstanceOf[DataTypeWithClass].cls), Some(elementType.asInstanceOf[DataTypeWithClass]))
+
+              case StructType(elementType: Array[StructField]) =>
+                val cls = otherTypeWrapper.cls
+                val names = elementType.map(_.name)
+
+                val beanInfo = Introspector.getBeanInfo(cls)
+                val methods = beanInfo.getMethodDescriptors.filter(it => names.contains(it.getName))
+
+
+                val fields = elementType.map { structField =>
+
+                  val maybeProp = methods.find(it => it.getName == structField.name)
+                  if (maybeProp.isEmpty) throw new IllegalArgumentException(s"Field ${structField.name} is not found among available props, which are: ${methods.map(_.getName).mkString(", ")}")
+                  val fieldName = structField.name
+                  val propClass = structField.dataType.asInstanceOf[DataTypeWithClass].cls
+                  val propDt = structField.dataType.asInstanceOf[DataTypeWithClass]
+                  val fieldValue = Invoke(
+                    inputObject,
+                    maybeProp.get.getName,
+                    inferExternalType(propClass),
+                    returnNullable = propDt.nullable
+                  )
+                  val newPath = walkedTypePath.recordField(propClass.getName, fieldName)
+                  (fieldName, serializerFor(fieldValue, getType(propClass), newPath, seenTypeSet, if (propDt.isInstanceOf[ComplexWrapper]) Some(propDt) else None))
+
+                }
+                createSerializerForObject(inputObject, fields)
+
               case _ =>
                 throw new UnsupportedOperationException(
                   s"No Encoder found for $tpe\n" + walkedTypePath)
 
             }
         }
+
+      case t if definedByConstructorParams(t) =>
+        if (seenTypeSet.contains(t)) {
+          throw new UnsupportedOperationException(
+            s"cannot have circular references in class, but got the circular reference of class $t")
+        }
+
+        val params = getConstructorParameters(t)
+        val fields = params.map { case (fieldName, fieldType) =>
+          if (javaKeywords.contains(fieldName)) {
+            throw new UnsupportedOperationException(s"`$fieldName` is a reserved keyword and " +
+              "cannot be used as field name\n" + walkedTypePath)
+          }
+
+          // SPARK-26730 inputObject won't be null with If's guard below. And KnownNotNul
+          // is necessary here. Because for a nullable nested inputObject with struct data
+          // type, e.g. StructType(IntegerType, StringType), it will return nullable=true
+          // for IntegerType without KnownNotNull. And that's what we do not expect to.
+          val fieldValue = Invoke(KnownNotNull(inputObject), fieldName, dataTypeFor(fieldType),
+            returnNullable = !fieldType.typeSymbol.asClass.isPrimitive)
+          val clsName = getClassNameFromType(fieldType)
+          val newPath = walkedTypePath.recordField(clsName, fieldName)
+          (fieldName, serializerFor(fieldValue, fieldType, newPath, seenTypeSet + t))
+        }
+        createSerializerForObject(inputObject, fields)
+
       case _ =>
         throw new UnsupportedOperationException(
           s"No Encoder found for $tpe\n" + walkedTypePath)

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -135,7 +135,6 @@ inline fun <reified T> encoder(): Encoder<T> = generateEncoder(typeOf<T>(), T::c
 fun <T> generateEncoder(type: KType, cls: KClass<*>): Encoder<T> {
     @Suppress("UNCHECKED_CAST")
     return when {
-        isTuple(cls) -> tupleEncoder(type)
         isSupportedClass(cls) -> kotlinClassEncoder(memoizedSchema(type), cls)
         else -> ENCODERS[cls] as? Encoder<T>? ?: bean(cls.java)
     } as Encoder<T>
@@ -144,6 +143,7 @@ fun <T> generateEncoder(type: KType, cls: KClass<*>): Encoder<T> {
 private fun isSupportedClass(cls: KClass<*>): Boolean = cls.isData
         || cls.isSubclassOf(Map::class)
         || cls.isSubclassOf(Iterable::class)
+        || cls.isSubclassOf(Product::class)
         || cls.java.isArray
 
 @Suppress("UNCHECKED_CAST")
@@ -157,45 +157,6 @@ private fun <T> kotlinClassEncoder(schema: DataType, kClass: KClass<*>): Encoder
             if (schema is DataTypeWithClass) KotlinReflection.deserializerFor(kClass.java, schema) else JavaTypeInference.deserializerFor(kClass.java),
             `ClassTag$`.`MODULE$`.apply(kClass.java)
     )
-}
-
-private fun isTuple(cls: KClass<*>): Boolean = listOf(
-    Tuple1::class,
-    Tuple2::class,
-    Tuple3::class,
-    Tuple4::class,
-    Tuple5::class,
-    Tuple6::class,
-    Tuple7::class,
-    Tuple8::class,
-    Tuple9::class,
-    Tuple10::class,
-    Tuple11::class,
-    Tuple12::class,
-    Tuple13::class,
-    Tuple14::class,
-    Tuple15::class,
-    Tuple16::class,
-    Tuple17::class,
-    Tuple18::class,
-    Tuple19::class,
-    Tuple20::class,
-    Tuple21::class,
-    Tuple22::class,
-).any { cls.isSubclassOf(it) }
-
-@Suppress("UNCHECKED_CAST")
-private fun <T> tupleEncoder(type: KType): Encoder<T> {
-    val encoders: List<Encoder<Any>> = type.arguments.map {
-        generateEncoder(it.type!!, it.type!!.jvmErasure)
-    }
-    return when (encoders.size) {
-        2 -> tuple(encoders[0], encoders[1])
-        3 -> tuple(encoders[0], encoders[1], encoders[2])
-        4 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3])
-        5 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3], encoders[4])
-        else -> throw IllegalArgumentException("Cannot encode a tuple with ${encoders.size} arguments at the moment.")
-    } as Encoder<T>
 }
 
 inline fun <reified T, reified R> Dataset<T>.map(noinline func: (T) -> R): Dataset<R> =
@@ -461,18 +422,18 @@ fun schema(type: KType, map: Map<String, KType> = mapOf()): DataType {
             KDataTypeWrapper(structType, klass.java, true)
         }
         klass.isSubclassOf(Product::class) -> {
-            throw IllegalArgumentException("$type is unsupported")
-            // TODO This should provide a datatype for products such as tuples but it does not work yet
+            val params = type.arguments.mapIndexed { i, it ->
+                "_${i + 1}" to it.type!!
+            }
 
             val structType = DataTypes.createStructType(
-                type.arguments.mapIndexed { i, it ->
-                    val projectedType = it.type!!
-                    val name = "_${i + 1}"
-                    val structField = StructField(name, schema(projectedType, types), projectedType.isMarkedNullable, Metadata.empty())
-                    KStructField(name, structField)
+                params.map { (fieldName, fieldType) ->
+                    val dataType = schema(fieldType, types)
+                    KStructField(fieldName, StructField(fieldName, dataType, fieldType.isMarkedNullable, Metadata.empty()))
                 }.toTypedArray()
             )
-            KDataTypeWrapper(structType, klass.java, type.isMarkedNullable)
+
+            KComplexTypeWrapper(structType, klass.java, true)
         }
         else -> throw IllegalArgumentException("$type is unsupported")
     }

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -36,6 +36,7 @@ import org.apache.spark.sql.streaming.GroupStateTimeout
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.*
 import org.jetbrains.kotlinx.spark.extensions.KSparkExtensions
+import scala.*
 import scala.collection.Seq
 import scala.reflect.`ClassTag$`
 import java.beans.PropertyDescriptor
@@ -51,6 +52,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
 @JvmField
@@ -133,6 +135,7 @@ inline fun <reified T> encoder(): Encoder<T> = generateEncoder(typeOf<T>(), T::c
 fun <T> generateEncoder(type: KType, cls: KClass<*>): Encoder<T> {
     @Suppress("UNCHECKED_CAST")
     return when {
+        isTuple(cls) -> tupleEncoder(type)
         isSupportedClass(cls) -> kotlinClassEncoder(memoizedSchema(type), cls)
         else -> ENCODERS[cls] as? Encoder<T>? ?: bean(cls.java)
     } as Encoder<T>
@@ -154,6 +157,45 @@ private fun <T> kotlinClassEncoder(schema: DataType, kClass: KClass<*>): Encoder
             if (schema is DataTypeWithClass) KotlinReflection.deserializerFor(kClass.java, schema) else JavaTypeInference.deserializerFor(kClass.java),
             `ClassTag$`.`MODULE$`.apply(kClass.java)
     )
+}
+
+private fun isTuple(cls: KClass<*>): Boolean = listOf(
+    Tuple1::class,
+    Tuple2::class,
+    Tuple3::class,
+    Tuple4::class,
+    Tuple5::class,
+    Tuple6::class,
+    Tuple7::class,
+    Tuple8::class,
+    Tuple9::class,
+    Tuple10::class,
+    Tuple11::class,
+    Tuple12::class,
+    Tuple13::class,
+    Tuple14::class,
+    Tuple15::class,
+    Tuple16::class,
+    Tuple17::class,
+    Tuple18::class,
+    Tuple19::class,
+    Tuple20::class,
+    Tuple21::class,
+    Tuple22::class,
+).any { cls.isSubclassOf(it) }
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> tupleEncoder(type: KType): Encoder<T> {
+    val encoders: List<Encoder<Any>> = type.arguments.map {
+        generateEncoder(it.type!!, it.type!!.jvmErasure)
+    }
+    return when (encoders.size) {
+        2 -> tuple(encoders[0], encoders[1])
+        3 -> tuple(encoders[0], encoders[1], encoders[2])
+        4 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3])
+        5 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3], encoders[4])
+        else -> throw IllegalArgumentException("Cannot encode a tuple with ${encoders.size} arguments at the moment.")
+    } as Encoder<T>
 }
 
 inline fun <reified T, reified R> Dataset<T>.map(noinline func: (T) -> R): Dataset<R> =
@@ -417,6 +459,20 @@ fun schema(type: KType, map: Map<String, KType> = mapOf()): DataType {
                             .toTypedArray()
             )
             KDataTypeWrapper(structType, klass.java, true)
+        }
+        klass.isSubclassOf(Product::class) -> {
+            throw IllegalArgumentException("$type is unsupported")
+            // TODO This should provide a datatype for products such as tuples but it does not work yet
+
+            val structType = DataTypes.createStructType(
+                type.arguments.mapIndexed { i, it ->
+                    val projectedType = it.type!!
+                    val name = "_${i + 1}"
+                    val structField = StructField(name, schema(projectedType, types), projectedType.isMarkedNullable, Metadata.empty())
+                    KStructField(name, structField)
+                }.toTypedArray()
+            )
+            KDataTypeWrapper(structType, klass.java, type.isMarkedNullable)
         }
         else -> throw IllegalArgumentException("$type is unsupported")
     }

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/Conversions.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/Conversions.kt
@@ -1,3 +1,22 @@
+/*-
+ * =LICENSE=
+ * Kotlin Spark API: API for Spark 2.4+ (Scala 2.12)
+ * ----------
+ * Copyright (C) 2019 - 2021 JetBrains
+ * ----------
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =LICENSEEND=
+ */
 @file:Suppress("NOTHING_TO_INLINE", "RemoveExplicitTypeArguments")
 
 package org.jetbrains.kotlinx.spark.api

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -311,26 +311,6 @@ class ApiTest : ShouldSpec({
                     Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
                     Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
                 )
-
-                dataset.show()
-                val asList = dataset.takeAsList(2)
-                asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
-            }
-            should("Be able to serialize data classes with tuples") {
-                val dataset = dsOf(
-                    DataClassWithTuple(Tuple2(5L, "test")),
-                    DataClassWithTuple(Tuple2(6L, "tessst")),
-                )
-
-                dataset.show()
-                val asList = dataset.takeAsList(2)
-                asList.first().tuple shouldBe Tuple2(5L, "test")
-            }
-            should("Be able to serialize Scala Tuples including data classes") {
-                val dataset = dsOf(
-                    Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
-                    Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
-                )
                 dataset.show()
                 val asList = dataset.takeAsList(2)
                 asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -22,6 +22,8 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import scala.Tuple2
+import scala.Tuple3
 import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
@@ -302,9 +304,31 @@ class ApiTest : ShouldSpec({
                 val dataset = dsOf(Timestamp(0L) to 2)
                 dataset.show()
             }
+            should("Be able to serialize Scala Tuples including data classes") {
+                val dataset = dsOf(
+                    Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
+                    Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
+            }
+            should("Be able to serialize data classes with tuples") {
+                val dataset = dsOf(
+                    DataClassWithTuple(Tuple2(5L, "test")),
+                    DataClassWithTuple(Tuple2(6L, "tessst")),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first().tuple shouldBe Tuple2(5L, "test")
+            }
         }
     }
 })
+
+data class DataClassWithTuple(val tuple: Tuple2<Long, String>)
 
 data class LonLat(val lon: Double, val lat: Double)
 data class Test<Z>(val id: Long, val data: Array<Pair<Z, Int>>) {

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -22,8 +22,6 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import scala.Tuple2
-import scala.Tuple3
 import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -26,6 +26,8 @@ import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
 import org.apache.spark.sql.Dataset
+import scala.Product
+import scala.Tuple1
 import scala.Tuple2
 import scala.Tuple3
 import java.io.Serializable
@@ -329,26 +331,26 @@ class ApiTest : ShouldSpec({
                     Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
                     Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
                 )
-
                 dataset.show()
                 val asList = dataset.takeAsList(2)
                 asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
             }
             should("Be able to serialize data classes with tuples") {
                 val dataset = dsOf(
-                    DataClassWithTuple(Tuple2(5L, "test")),
-                    DataClassWithTuple(Tuple2(6L, "tessst")),
+                    DataClassWithTuple(Tuple3(5L, "test", Tuple1(""))),
+                    DataClassWithTuple(Tuple3(6L, "tessst", Tuple1(""))),
                 )
 
                 dataset.show()
                 val asList = dataset.takeAsList(2)
-                asList.first().tuple shouldBe Tuple2(5L, "test")
+                asList.first().tuple shouldBe Tuple3(5L, "test", Tuple1(""))
             }
         }
     }
 })
 
-data class DataClassWithTuple(val tuple: Tuple2<Long, String>)
+data class DataClassWithTuple<T : Product>(val tuple: T)
+
 
 data class LonLat(val lon: Double, val lat: Double)
 data class Test<Z>(val id: Long, val data: Array<Pair<Z, Int>>) {

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -133,7 +133,6 @@ inline fun <reified T> encoder(): Encoder<T> = generateEncoder(typeOf<T>(), T::c
 fun <T> generateEncoder(type: KType, cls: KClass<*>): Encoder<T> {
     @Suppress("UNCHECKED_CAST")
     return when {
-        isTuple(cls) -> tupleEncoder(type)
         isSupportedClass(cls) -> kotlinClassEncoder(memoizedSchema(type), cls)
         else -> ENCODERS[cls] as? Encoder<T>? ?: bean(cls.java)
     } as Encoder<T>
@@ -151,45 +150,6 @@ private fun <T> kotlinClassEncoder(schema: DataType, kClass: KClass<*>): Encoder
             if (schema is DataTypeWithClass) KotlinReflection.deserializerFor(kClass.java, schema) else KotlinReflection.deserializerForType(KotlinReflection.getType(kClass.java)),
             ClassTag.apply(kClass.java)
     )
-}
-
-private fun isTuple(cls: KClass<*>): Boolean = listOf(
-    Tuple1::class,
-    Tuple2::class,
-    Tuple3::class,
-    Tuple4::class,
-    Tuple5::class,
-    Tuple6::class,
-    Tuple7::class,
-    Tuple8::class,
-    Tuple9::class,
-    Tuple10::class,
-    Tuple11::class,
-    Tuple12::class,
-    Tuple13::class,
-    Tuple14::class,
-    Tuple15::class,
-    Tuple16::class,
-    Tuple17::class,
-    Tuple18::class,
-    Tuple19::class,
-    Tuple20::class,
-    Tuple21::class,
-    Tuple22::class,
-).any { cls.isSubclassOf(it) }
-
-@Suppress("UNCHECKED_CAST")
-private fun <T> tupleEncoder(type: KType): Encoder<T> {
-    val encoders: List<Encoder<Any>> = type.arguments.map {
-        generateEncoder(it.type!!, it.type!!.jvmErasure)
-    }
-    return when (encoders.size) {
-        2 -> tuple(encoders[0], encoders[1])
-        3 -> tuple(encoders[0], encoders[1], encoders[2])
-        4 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3])
-        5 -> tuple(encoders[0], encoders[1], encoders[2], encoders[3], encoders[4])
-        else -> throw IllegalArgumentException("Cannot encode a tuple with ${encoders.size} arguments at the moment.")
-    } as Encoder<T>
 }
 
 inline fun <reified T, reified R> Dataset<T>.map(noinline func: (T) -> R): Dataset<R> =
@@ -452,20 +412,18 @@ fun schema(type: KType, map: Map<String, KType> = mapOf()): DataType {
             KDataTypeWrapper(structType, klass.java, true)
         }
         klass.isSubclassOf(Product::class) -> {
-            //throw IllegalArgumentException("$type is unsupported")
-            // TODO This should provide a datatype for products such as tuples but it does not work yet
-
             val params = type.arguments.mapIndexed { i, it ->
                 "_${i + 1}" to it.type!!
             }
 
-            val structType = StructType(
+            val structType = DataTypes.createStructType(
                 params.map { (fieldName, fieldType) ->
                     val dataType = schema(fieldType, types)
-                    StructField(fieldName, dataType, true, Metadata.empty())
+                    KStructField(fieldName, StructField(fieldName, dataType, fieldType.isMarkedNullable, Metadata.empty()))
                 }.toTypedArray()
             )
-            KDataTypeWrapper(structType, klass.java, true)
+
+            KComplexTypeWrapper(structType, klass.java, true)
         }
         else -> throw IllegalArgumentException("$type is unsupported")
     }

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -22,12 +22,14 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import scala.Tuple1
 import scala.Tuple2
 import scala.Tuple3
 import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
 import org.apache.spark.sql.Dataset
+import scala.Product
 import java.io.Serializable
 import java.sql.Date
 import java.sql.Timestamp
@@ -331,41 +333,25 @@ class ApiTest : ShouldSpec({
                     Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
                     Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
                 )
-
                 dataset.show()
                 val asList = dataset.takeAsList(2)
                 asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
             }
             should("Be able to serialize data classes with tuples") {
                 val dataset = dsOf(
-                    DataClassWithTuple(Tuple2(5L, "test")),
-                    DataClassWithTuple(Tuple2(6L, "tessst")),
+                    DataClassWithTuple(Tuple3(5L, "test", Tuple1(""))),
+                    DataClassWithTuple(Tuple3(6L, "tessst", Tuple1(""))),
                 )
 
                 dataset.show()
                 val asList = dataset.takeAsList(2)
-                asList.first().tuple shouldBe Tuple2(5L, "test")
-            }
-            should("Be able to serialize list with tuples") {
-                val dataset = dsOf(
-                    listOf(Tuple2(5L, Tuple2(6L, "tessst"))),
-                )
-
-                dataset.show()
-                val asList = dataset.takeAsList(2)
-                asList.first() shouldBe Tuple2(5L, "test")
-            }
-            should("Be able to serialize a list with data classes") {
-                val dataset = dsOf(
-                    listOf(SomeClass(intArrayOf(1, 2, 3), 4))
-                )
-                dataset.show()
+                asList.first().tuple shouldBe Tuple3(5L, "test", Tuple1(""))
             }
         }
     }
 })
 
-data class DataClassWithTuple(val tuple: Tuple2<Long, String>)
+data class DataClassWithTuple<T : Product>(val tuple: T)
 
 data class LonLat(val lon: Double, val lat: Double)
 

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -22,6 +22,8 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import scala.Tuple2
+import scala.Tuple3
 import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
@@ -324,9 +326,31 @@ class ApiTest : ShouldSpec({
                 val dataset = dsOf(Timestamp(0L) to 2)
                 dataset.show()
             }
+            should("Be able to serialize Scala Tuples including data classes") {
+                val dataset = dsOf(
+                    Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
+                    Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
+            }
+            should("Be able to serialize data classes with tuples") {
+                val dataset = dsOf(
+                    DataClassWithTuple(Tuple2(5L, "test")),
+                    DataClassWithTuple(Tuple2(6L, "tessst")),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first().tuple shouldBe Tuple2(5L, "test")
+            }
         }
     }
 })
+
+data class DataClassWithTuple(val tuple: Tuple2<Long, String>)
 
 data class LonLat(val lon: Double, val lat: Double)
 

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -346,6 +346,21 @@ class ApiTest : ShouldSpec({
                 val asList = dataset.takeAsList(2)
                 asList.first().tuple shouldBe Tuple2(5L, "test")
             }
+            should("Be able to serialize list with tuples") {
+                val dataset = dsOf(
+                    listOf(Tuple2(5L, Tuple2(6L, "tessst"))),
+                )
+
+                dataset.show()
+                val asList = dataset.takeAsList(2)
+                asList.first() shouldBe Tuple2(5L, "test")
+            }
+            should("Be able to serialize a list with data classes") {
+                val dataset = dsOf(
+                    listOf(SomeClass(intArrayOf(1, 2, 3), 4))
+                )
+                dataset.show()
+            }
         }
     }
 })

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -28,8 +28,6 @@ import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
 import org.apache.spark.sql.Dataset
-import scala.Tuple2
-import scala.Tuple3
 import java.io.Serializable
 import java.sql.Date
 import java.sql.Timestamp
@@ -362,26 +360,6 @@ class ApiTest : ShouldSpec({
                     listOf(SomeClass(intArrayOf(1, 2, 3), 4))
                 )
                 dataset.show()
-            }
-            should("Be able to serialize Scala Tuples including data classes") {
-                val dataset = dsOf(
-                    Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0))),
-                    Tuple2("b", Tuple3("b", 2, LonLat(1.0, 2.0))),
-                )
-
-                dataset.show()
-                val asList = dataset.takeAsList(2)
-                asList.first() shouldBe Tuple2("a", Tuple3("a", 1, LonLat(1.0, 1.0)))
-            }
-            should("Be able to serialize data classes with tuples") {
-                val dataset = dsOf(
-                    DataClassWithTuple(Tuple2(5L, "test")),
-                    DataClassWithTuple(Tuple2(6L, "tessst")),
-                )
-
-                dataset.show()
-                val asList = dataset.takeAsList(2)
-                asList.first().tuple shouldBe Tuple2(5L, "test")
             }
         }
     }


### PR DESCRIPTION
Tuples of all sizes can now be encoded in Datasets because it doesn't use the `Encoders.tuple()` functions from Spark anymore.
I used the method similar to Kotlin data classes but with another wrapper and I edited the Scala files as well. 
I have had little experience with Scala, but borrowing code from other places in the file I managed to get the tests to work.

This continues the work from https://github.com/JetBrains/kotlin-spark-api/pull/79
And is discussed here https://github.com/JetBrains/kotlin-spark-api/issues/76
