### PR TITLE
[Feat] Adds Dataset selectTyped functions

### DIFF
--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -357,6 +357,49 @@ inline fun <reified R> Dataset<*>.toArray(): Array<R> = to<R>().collect() as Arr
  */
 fun <T> Dataset<T>.showDS(numRows: Int = 20, truncate: Boolean = true) = apply { show(numRows, truncate) }
 
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+): Dataset<Pair<U1, U2>> =
+    select(c1, c2).map { Pair(it._1(), it._2()) }
+
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2, U3> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+    c3: TypedColumn<T, U3>,
+): Dataset<Triple<U1, U2, U3>> =
+    select(c1, c2, c3).map { Triple(it._1(), it._2(), it._3()) }
+
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2, U3, U4> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+    c3: TypedColumn<T, U3>,
+    c4: TypedColumn<T, U4>,
+): Dataset<Arity4<U1, U2, U3, U4>> =
+    select(c1, c2, c3, c4).map { Arity4(it._1(), it._2(), it._3(), it._4()) }
+
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2, U3, U4, U5> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+    c3: TypedColumn<T, U3>,
+    c4: TypedColumn<T, U4>,
+    c5: TypedColumn<T, U5>,
+): Dataset<Arity5<U1, U2, U3, U4, U5>> =
+    select(c1, c2, c3, c4, c5).map { Arity5(it._1(), it._2(), it._3(), it._4(), it._5()) }
+
+
 @OptIn(ExperimentalStdlibApi::class)
 inline fun <reified T> schema(map: Map<String, KType> = mapOf()) = schema(typeOf<T>(), map)
 

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -360,7 +360,7 @@ fun <T> Dataset<T>.showDS(numRows: Int = 20, truncate: Boolean = true) = apply {
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
 ): Dataset<Pair<U1, U2>> =
@@ -369,7 +369,7 @@ fun <T, U1, U2> Dataset<T>.selectTyped(
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2, U3> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2, reified U3> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
     c3: TypedColumn<T, U3>,
@@ -379,7 +379,7 @@ fun <T, U1, U2, U3> Dataset<T>.selectTyped(
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2, U3, U4> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2, reified U3, reified U4> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
     c3: TypedColumn<T, U3>,
@@ -390,7 +390,7 @@ fun <T, U1, U2, U3, U4> Dataset<T>.selectTyped(
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2, U3, U4, U5> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2, reified U3, reified U4, reified U5> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
     c3: TypedColumn<T, U3>,

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -26,6 +26,7 @@ import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.TypedColumn
 import scala.Product
 import scala.Tuple1
 import scala.Tuple2
@@ -324,6 +325,42 @@ class ApiTest : ShouldSpec({
                 dataset.show()
                 val asList = dataset.takeAsList(2)
                 asList.first().tuple shouldBe Tuple3(5L, "test", Tuple1(""))
+            }
+            should("support dataset select") {
+                val dataset = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 3),
+                    SomeClass(intArrayOf(1, 2, 4), 5),
+                )
+
+                val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS2.show()
+
+                val newDS3: Dataset<Triple<IntArray, Int, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS3.show()
+
+                val newDS4: Dataset<Arity4<IntArray, Int, Int, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS4.show()
+
+                val newDS5: Dataset<Arity5<IntArray, Int, Int, Int, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS5.show()
             }
         }
     }

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -326,6 +326,7 @@ class ApiTest : ShouldSpec({
                 val asList = dataset.takeAsList(2)
                 asList.first().tuple shouldBe Tuple3(5L, "test", Tuple1(""))
             }
+            @Suppress("UNCHECKED_CAST")
             should("support dataset select") {
                 val dataset = dsOf(
                     SomeClass(intArrayOf(1, 2, 3), 3),

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -441,13 +441,6 @@ class ApiTest : ShouldSpec({
     }
 })
 
-/**
- * TODO TEMP
- */
-@Suppress("UNCHECKED_CAST")
-inline fun <reified T, reified U> col(column: KProperty1<T, U>): TypedColumn<T, U> =
-    col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
-
 
 data class DataClassWithTuple<T : Product>(val tuple: T)
 

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -370,7 +370,8 @@ class ApiTest : ShouldSpec({
     }
 })
 
-inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`(encoder<U>()) as TypedColumn<T, U>
+inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
+
 
 data class DataClassWithTuple<T : Product>(val tuple: T)
 

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -332,6 +332,8 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(1, 2, 4), 5),
                 )
 
+                val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder<IntArray>())
+
                 val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
                     dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
                     dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -27,6 +27,7 @@ import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.TypedColumn
+import org.apache.spark.sql.functions.*
 import scala.Product
 import scala.Tuple1
 import scala.Tuple2
@@ -334,35 +335,36 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(1, 2, 4), 5),
                 )
 
-                val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder<IntArray>())
+                val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder())
 
-                val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
+                val newDS2 = dataset.selectTyped(
+//                    col(SomeClass::a), NOTE that this doesn't work on 2.4, returnting a data class with an array in it
+                    col(SomeClass::b),
+                    col(SomeClass::b),
                 )
                 newDS2.show()
 
-                val newDS3: Dataset<Triple<IntArray, Int, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
+                val newDS3 = dataset.selectTyped(
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
                 )
                 newDS3.show()
 
-                val newDS4: Dataset<Arity4<IntArray, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
+                val newDS4 = dataset.selectTyped(
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
                 )
                 newDS4.show()
 
-                val newDS5: Dataset<Arity5<IntArray, Int, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
+                val newDS5 = dataset.selectTyped(
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
                 )
                 newDS5.show()
             }
@@ -370,7 +372,12 @@ class ApiTest : ShouldSpec({
     }
 })
 
-inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
+/**
+ * TODO TEMP
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T, reified U> col(column: KProperty1<T, U>): TypedColumn<T, U> =
+    col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
 
 
 data class DataClassWithTuple<T : Product>(val tuple: T)

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -35,6 +35,7 @@ import java.io.Serializable
 import java.sql.Date
 import java.sql.Timestamp
 import java.time.LocalDate
+import kotlin.reflect.KProperty1
 import scala.collection.Iterator as ScalaIterator
 import scala.collection.Map as ScalaMap
 import scala.collection.mutable.Map as ScalaMutableMap
@@ -336,38 +337,40 @@ class ApiTest : ShouldSpec({
                 val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder<IntArray>())
 
                 val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
                 )
                 newDS2.show()
 
                 val newDS3: Dataset<Triple<IntArray, Int, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
                 )
                 newDS3.show()
 
                 val newDS4: Dataset<Arity4<IntArray, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
                 )
                 newDS4.show()
 
                 val newDS5: Dataset<Arity5<IntArray, Int, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
                 )
                 newDS5.show()
             }
         }
     }
 })
+
+inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`(encoder<U>()) as TypedColumn<T, U>
 
 data class DataClassWithTuple<T : Product>(val tuple: T)
 

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -353,6 +353,49 @@ inline fun <reified R> Dataset<*>.toArray(): Array<R> = to<R>().collect() as Arr
  */
 fun <T> Dataset<T>.showDS(numRows: Int = 20, truncate: Boolean = true) = apply { show(numRows, truncate) }
 
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+): Dataset<Pair<U1, U2>> =
+    select(c1, c2).map { Pair(it._1(), it._2()) }
+
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2, U3> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+    c3: TypedColumn<T, U3>,
+): Dataset<Triple<U1, U2, U3>> =
+    select(c1, c2, c3).map { Triple(it._1(), it._2(), it._3()) }
+
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2, U3, U4> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+    c3: TypedColumn<T, U3>,
+    c4: TypedColumn<T, U4>,
+): Dataset<Arity4<U1, U2, U3, U4>> =
+    select(c1, c2, c3, c4).map { Arity4(it._1(), it._2(), it._3(), it._4()) }
+
+/**
+ * Returns a new Dataset by computing the given [Column] expressions for each element.
+ */
+fun <T, U1, U2, U3, U4, U5> Dataset<T>.selectTyped(
+    c1: TypedColumn<T, U1>,
+    c2: TypedColumn<T, U2>,
+    c3: TypedColumn<T, U3>,
+    c4: TypedColumn<T, U4>,
+    c5: TypedColumn<T, U5>,
+): Dataset<Arity5<U1, U2, U3, U4, U5>> =
+    select(c1, c2, c3, c4, c5).map { Arity5(it._1(), it._2(), it._3(), it._4(), it._5()) }
+
+
 @OptIn(ExperimentalStdlibApi::class)
 fun schema(type: KType, map: Map<String, KType> = mapOf()): DataType {
     val primitiveSchema = knownDataTypes[type.classifier]

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -356,7 +356,7 @@ fun <T> Dataset<T>.showDS(numRows: Int = 20, truncate: Boolean = true) = apply {
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
 ): Dataset<Pair<U1, U2>> =
@@ -365,7 +365,7 @@ fun <T, U1, U2> Dataset<T>.selectTyped(
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2, U3> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2, reified U3> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
     c3: TypedColumn<T, U3>,
@@ -375,7 +375,7 @@ fun <T, U1, U2, U3> Dataset<T>.selectTyped(
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2, U3, U4> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2, reified U3, reified U4> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
     c3: TypedColumn<T, U3>,
@@ -386,7 +386,7 @@ fun <T, U1, U2, U3, U4> Dataset<T>.selectTyped(
 /**
  * Returns a new Dataset by computing the given [Column] expressions for each element.
  */
-fun <T, U1, U2, U3, U4, U5> Dataset<T>.selectTyped(
+inline fun <reified T, reified U1, reified U2, reified U3, reified U4, reified U5> Dataset<T>.selectTyped(
     c1: TypedColumn<T, U1>,
     c2: TypedColumn<T, U2>,
     c3: TypedColumn<T, U3>,

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -29,6 +29,7 @@ import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.TypedColumn
 import scala.Product
 import java.io.Serializable
 import java.sql.Date
@@ -352,6 +353,36 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(1, 2, 3), 3),
                     SomeClass(intArrayOf(1, 2, 4), 5),
                 )
+
+                val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS2.show()
+
+                val newDS3: Dataset<Triple<IntArray, Int, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS3.show()
+
+                val newDS4: Dataset<Arity4<IntArray, Int, Int, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS4.show()
+
+                val newDS5: Dataset<Arity5<IntArray, Int, Int, Int, Int>> = dataset.selectTyped(
+                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                )
+                newDS5.show()
             }
         }
     }

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -354,6 +354,8 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(1, 2, 4), 5),
                 )
 
+                val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder<IntArray>())
+
                 val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
                     dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
                     dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -36,6 +36,7 @@ import java.sql.Date
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
+import kotlin.reflect.KProperty1
 import scala.collection.Iterator as ScalaIterator
 import scala.collection.Map as ScalaMap
 import scala.collection.mutable.Map as ScalaMutableMap
@@ -358,38 +359,41 @@ class ApiTest : ShouldSpec({
                 val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder<IntArray>())
 
                 val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
                 )
                 newDS2.show()
 
                 val newDS3: Dataset<Triple<IntArray, Int, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
                 )
                 newDS3.show()
 
                 val newDS4: Dataset<Arity4<IntArray, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
                 )
                 newDS4.show()
 
                 val newDS5: Dataset<Arity5<IntArray, Int, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col("a").`as`(encoder<IntArray>()) as TypedColumn<SomeClass, IntArray>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
-                    dataset.col("b").`as`(encoder<Int>()) as TypedColumn<SomeClass, Int>,
+                    dataset.col(SomeClass::a),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
+                    dataset.col(SomeClass::b),
                 )
                 newDS5.show()
             }
         }
     }
 })
+
+inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`(encoder<U>()) as TypedColumn<T, U>
+
 
 data class DataClassWithTuple<T : Product>(val tuple: T)
 

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -347,6 +347,12 @@ class ApiTest : ShouldSpec({
                 val asList = dataset.takeAsList(2)
                 asList.first().tuple shouldBe Tuple3(5L, "test", Tuple1(""))
             }
+            should("support dataset select") {
+                val dataset = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 3),
+                    SomeClass(intArrayOf(1, 2, 4), 5),
+                )
+            }
         }
     }
 })

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -392,7 +392,7 @@ class ApiTest : ShouldSpec({
     }
 })
 
-inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`(encoder<U>()) as TypedColumn<T, U>
+inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
 
 
 data class DataClassWithTuple<T : Product>(val tuple: T)

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -348,6 +348,7 @@ class ApiTest : ShouldSpec({
                 val asList = dataset.takeAsList(2)
                 asList.first().tuple shouldBe Tuple3(5L, "test", Tuple1(""))
             }
+            @Suppress("UNCHECKED_CAST")
             should("support dataset select") {
                 val dataset = dsOf(
                     SomeClass(intArrayOf(1, 2, 3), 3),

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -22,9 +22,6 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.TypedColumn
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.GroupState
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.Product
@@ -35,7 +32,6 @@ import scala.collection.Seq
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.TypedColumn
 import org.apache.spark.sql.functions.*
-import scala.Product
 import java.io.Serializable
 import java.sql.Date
 import java.sql.Timestamp
@@ -484,15 +480,6 @@ class ApiTest : ShouldSpec({
         }
     }
 })
-
-/**
- * TODO TEMP
- */
-@Suppress("UNCHECKED_CAST")
-inline fun <reified T, reified U> col(column: KProperty1<T, U>): TypedColumn<T, U> =
-        col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
-
-
 
 data class DataClassWithTuple<T : Product>(val tuple: T)
 

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -22,15 +22,16 @@ import ch.tutteli.atrium.domain.builders.migration.asExpect
 import ch.tutteli.atrium.verbs.expect
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.TypedColumn
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.streaming.GroupState
+import org.apache.spark.sql.streaming.GroupStateTimeout
+import scala.Product
 import scala.Tuple1
 import scala.Tuple2
 import scala.Tuple3
-import org.apache.spark.sql.streaming.GroupState
-import org.apache.spark.sql.streaming.GroupStateTimeout
 import scala.collection.Seq
-import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.TypedColumn
-import scala.Product
 import java.io.Serializable
 import java.sql.Date
 import java.sql.Timestamp
@@ -356,35 +357,35 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(1, 2, 4), 5),
                 )
 
-                val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder<IntArray>())
+                val typedColumnA: TypedColumn<Any, IntArray> = dataset.col("a").`as`(encoder())
 
-                val newDS2: Dataset<Pair<IntArray, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
+                val newDS2 = dataset.selectTyped(
+                    col(SomeClass::a), // NOTE: this only works on 3.0, returning a data class with an array in it
+                    col(SomeClass::b),
                 )
                 newDS2.show()
 
-                val newDS3: Dataset<Triple<IntArray, Int, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
+                val newDS3 = dataset.selectTyped(
+                    col(SomeClass::a),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
                 )
                 newDS3.show()
 
-                val newDS4: Dataset<Arity4<IntArray, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
+                val newDS4 = dataset.selectTyped(
+                    col(SomeClass::a),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
                 )
                 newDS4.show()
 
-                val newDS5: Dataset<Arity5<IntArray, Int, Int, Int, Int>> = dataset.selectTyped(
-                    dataset.col(SomeClass::a),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
-                    dataset.col(SomeClass::b),
+                val newDS5 = dataset.selectTyped(
+                    col(SomeClass::a),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
+                    col(SomeClass::b),
                 )
                 newDS5.show()
             }
@@ -392,7 +393,13 @@ class ApiTest : ShouldSpec({
     }
 })
 
-inline fun <reified T, reified U> Dataset<T>.col(column: KProperty1<T, U>): TypedColumn<T, U> = col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
+/**
+ * TODO TEMP
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T, reified U> col(column: KProperty1<T, U>): TypedColumn<T, U> =
+        col(column.name).`as`<U>(encoder<U>()) as TypedColumn<T, U>
+
 
 
 data class DataClassWithTuple<T : Product>(val tuple: T)


### PR DESCRIPTION
As discussed in the issue: https://github.com/JetBrains/kotlin-spark-api/issues/85
This adds the `selectTyped()` functions for `Dataset`s.
The results are mapped to `Pair`s, `Triple`s or `Arity`s for the respective amount of arguments given.

The creation of `TypedColumn`s is made a lot easier using a different pull request: https://github.com/JetBrains/kotlin-spark-api/pull/87, which I recommend to merge first, so that the temporary `col()` function in the tests here can be removed before merging :).

Note that on 2.4 the `selectTyped()` function cannot return a `Dataset` of a data class of an array. This is an encoding limitation which I mention here https://github.com/JetBrains/kotlin-spark-api/issues/64 as well.