### PR TITLE
[Bugfix] Encoding Lists of data classes / tuples for 3.0

### DIFF
--- a/core/3.0/src/main/scala/org/apache/spark/sql/KotlinReflection.scala
+++ b/core/3.0/src/main/scala/org/apache/spark/sql/KotlinReflection.scala
@@ -421,6 +421,7 @@ object KotlinReflection extends KotlinReflection {
                   "toJavaMap",
                   keyData :: valueData :: Nil,
                   returnNullable = false)
+
               case ArrayType(elementType, containsNull) =>
                 val dataTypeWithClass = elementType.asInstanceOf[DataTypeWithClass]
                 val mapFunction: Expression => Expression = element => {
@@ -434,7 +435,7 @@ object KotlinReflection extends KotlinReflection {
                     nullable = dataTypeWithClass.nullable,
                     newTypePath,
                     (casted, typePath) => {
-                      deserializerFor(et, casted, typePath, Some(dataTypeWithClass.dt).filter(_.isInstanceOf[ComplexWrapper]).map(_.asInstanceOf[ComplexWrapper]))
+                      deserializerFor(et, casted, typePath, Some(dataTypeWithClass).filter(_.isInstanceOf[ComplexWrapper]).map(_.asInstanceOf[ComplexWrapper]))
                     })
                 }
 

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -354,6 +354,13 @@ class ApiTest : ShouldSpec({
                 )
                 dataset.show()
             }
+            should("Be able to serialize arrays of data classes") {
+                val dataset = dsOf(
+                    arrayOf(SomeClass(intArrayOf(1, 2, 3), 4)),
+                    arrayOf(SomeClass(intArrayOf(3, 2, 1), 0)),
+                )
+                dataset.show()
+            }
             should("Be able to serialize lists of tuples") {
                 val dataset = dsOf(
                     listOf(Tuple2(intArrayOf(1, 2, 3), 4)),

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -347,6 +347,20 @@ class ApiTest : ShouldSpec({
                 val asList = dataset.takeAsList(2)
                 asList.first().tuple shouldBe Tuple3(5L, "test", Tuple1(""))
             }
+            should("Be able to serialize lists of data classes") {
+                val dataset = dsOf(
+                    listOf(SomeClass(intArrayOf(1, 2, 3), 4)),
+                    listOf(SomeClass(intArrayOf(3, 2, 1), 0)),
+                )
+                dataset.show()
+            }
+            should("Be able to serialize lists of tuples") {
+                val dataset = dsOf(
+                    listOf(Tuple2(intArrayOf(1, 2, 3), 4)),
+                    listOf(Tuple2(intArrayOf(3, 2, 1), 0)),
+                )
+                dataset.show()
+            }
         }
     }
 })


### PR DESCRIPTION
As described by the issue here https://github.com/JetBrains/kotlin-spark-api/issues/86, this fixes the encoding for lists/arrays of complex objects.
For now it only works on 3.0, as I suspect the reason it doesn't work for 2.4 is due to https://github.com/JetBrains/kotlin-spark-api/issues/64 as well.
@asm0dey 