### PR TITLE
Some more useful helper / wrapper functions

### DIFF
--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -437,10 +437,42 @@ class ApiTest : ShouldSpec({
 
                 b.count() shouldBe 1
             }
+            should("Allow simple forEachPartition in datasets") {
+                val dataset = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 1),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                dataset.forEachPartition {
+                    it.forEach {
+                        it.b shouldBe  1
+                    }
+                }
+            }
+            should("Have easier access to keys and values for key/value datasets") {
+                val dataset: Dataset<SomeClass> = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 1),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                    .groupByKey { it.b }
+                    .reduceGroups(func = { a, b -> SomeClass(a.a + b.a, a.b) })
+                    .takeValues()
+
+                dataset.count() shouldBe 1
+            }
+            should("Be able to sort datasets with property reference") {
+                val dataset: Dataset<SomeClass> = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 2),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                dataset.sort(SomeClass::b)
+                dataset.takeAsList(1).first().b shouldBe 2
+
+                dataset.sort(SomeClass::a, SomeClass::b)
+                dataset.takeAsList(1).first().b shouldBe 2
+            }
         }
     }
 })
-
 
 data class DataClassWithTuple<T : Product>(val tuple: T)
 

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -176,6 +176,23 @@ inline fun <reified KEY, reified VALUE> KeyValueGroupedDataset<KEY, VALUE>.reduc
         reduceGroups(ReduceFunction(func))
                 .map { t -> t._1 to t._2 }
 
+@JvmName("takeKeysTuple2")
+inline fun <reified T1, T2> Dataset<Tuple2<T1, T2>>.takeKeys(): Dataset<T1> = map { it._1() }
+
+inline fun <reified T1, T2> Dataset<Pair<T1, T2>>.takeKeys(): Dataset<T1> = map { it.first }
+
+@JvmName("takeKeysArity2")
+inline fun <reified T1, T2> Dataset<Arity2<T1, T2>>.takeKeys(): Dataset<T1> = map { it._1 }
+
+@JvmName("takeValuesTuple2")
+inline fun <T1, reified T2> Dataset<Tuple2<T1, T2>>.takeValues(): Dataset<T2> = map { it._2() }
+
+inline fun <T1, reified T2> Dataset<Pair<T1, T2>>.takeValues(): Dataset<T2> = map { it.second }
+
+@JvmName("takeValuesArity2")
+inline fun <T1, reified T2> Dataset<Arity2<T1, T2>>.takeValues(): Dataset<T2> = map { it._2 }
+
+
 inline fun <K, V, reified U> KeyValueGroupedDataset<K, V>.flatMapGroups(
     noinline func: (key: K, values: Iterator<V>) -> Iterator<U>
 ): Dataset<U> = flatMapGroups(
@@ -233,6 +250,8 @@ inline fun <reified R> Dataset<*>.`as`(): Dataset<R> = `as`(encoder<R>())
 inline fun <reified R> Dataset<*>.to(): Dataset<R> = `as`(encoder<R>())
 
 inline fun <reified T> Dataset<T>.forEach(noinline func: (T) -> Unit) = foreach(ForeachFunction(func))
+
+inline fun <reified T> Dataset<T>.forEachPartition(noinline func: (Iterator<T>) -> Unit) = foreachPartition(ForeachPartitionFunction(func))
 
 /**
  * It's hard to call `Dataset.debugCodegen` from kotlin, so here is utility for that
@@ -713,6 +732,16 @@ inline fun <reified T, reified U> col(column: KProperty1<T, U>): TypedColumn<T, 
  * @see col
  */
 inline operator fun <reified T, reified U> Dataset<T>.invoke(column: KProperty1<T, U>): TypedColumn<T, U> = col(column)
+
+/**
+ * Allows to sort data class dataset on one or more of the properties of the data class.
+ * ```kotlin
+ * val sorted: Dataset<YourClass> = unsorted.sort(YourClass::a)
+ * val sorted2: Dataset<YourClass> = unsorted.sort(YourClass::a, YourClass::b)
+ * ```
+ */
+fun <T> Dataset<T>.sort(col: KProperty1<T, *>, vararg cols: KProperty1<T, *>): Dataset<T> =
+    sort(col.name, *cols.map { it.name }.toTypedArray())
 
 /**
  * Alternative to [Dataset.show] which returns source dataset.

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -477,6 +477,39 @@ class ApiTest : ShouldSpec({
                 )
                 dataset.show()
             }
+            should("Allow simple forEachPartition in datasets") {
+                val dataset = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 1),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                dataset.forEachPartition {
+                    it.forEach {
+                        it.b shouldBe  1
+                    }
+                }
+            }
+            should("Have easier access to keys and values for key/value datasets") {
+                val dataset: Dataset<SomeClass> = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 1),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                    .groupByKey { it.b }
+                    .reduceGroups(func = { a, b -> SomeClass(a.a + b.a, a.b) })
+                    .takeValues()
+
+                dataset.count() shouldBe 1
+            }
+            should("Be able to sort datasets with property reference") {
+                val dataset: Dataset<SomeClass> = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 2),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                dataset.sort(SomeClass::b)
+                dataset.takeAsList(1).first().b shouldBe 2
+
+                dataset.sort(SomeClass::a, SomeClass::b)
+                dataset.takeAsList(1).first().b shouldBe 2
+            }
         }
     }
 })


### PR DESCRIPTION
Just a couple of small things I came across while working with the library.

Firstly, `dataset.foreachPartition { }` has overload resolution ambiguity, so I added `forEachPartition {}` to the API.

Secondly, some functions (like `reduceGroups()`) return a `Dataset<Pair<K, V>>`, or the user creates a key/value like dataset themselves and then it might be useful to just take the keys or the values (I know I found it useful).
So I added `takeKeys()` and `takeValues()` for `Dataset<Pair>`, `Dataset<Tuple2>`, and `Dataset<Arity2>`. It's a small thing, but might improve readability.

Lastly, just like getting the columns using property references, it might also be useful to sort datasets using those, so I added the ability to do:
```kotlin
val sorted: Dataset<YourClass> = unsorted.sort(YourClass::a)
val sorted2: Dataset<YourClass> = unsorted.sort(YourClass::a, YourClass::b)
```

@asm0dey let me know if these are helpful :)