### PR TITLE
Switch to Maven Central since jCenter quit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,15 +344,24 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
+            <id>central</id>
+            <name>Maven Central</name>
+            <layout>default</layout>
+            <url>https://repo1.maven.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
+            <id>central</id>
+            <name>Maven Central</name>
+            <layout>default</layout>
+            <url>https://repo1.maven.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </pluginRepository>
     </pluginRepositories>
 </project>


### PR DESCRIPTION
@asm0dey Obviously, if you want to use another repo, let me know!
But since jCenter quit (https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), we need to switch to another repo for the dependencies.
Maven Central seems to work fine!