### PR TITLE
Fixing more overload res ambiguity: reduceK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We have opened a Spark Project Improvement Proposal: [Kotlin support for Apache 
     - [withCached function](#withcached-function)
     - [toList and toArray](#tolist-and-toarray-methods)
     - [Column infix/operator functions](#column-infixoperator-functions)
-    - [`reduceGroups`](#reducegroups)
+    - [Overload Resolution Ambiguity](#overload-resolution-ambiguity)
 - [Examples](#examples)
 - [Reporting issues/Support](#reporting-issuessupport)
 - [Code of Conduct](#code-of-conduct)
@@ -190,9 +190,9 @@ val dataset: Dataset<YourClass> = ...
 val newDataset: Dataset<Pair<TypeA, TypeB>> = dataset.selectTyped(col(YourClass::colA), col(YourClass::colB))
 ```
 
-### `reduceGroups`
+### Overload resolution ambiguity
 
-We had to implemet `reduceGroups` operator for Kotlin separately as `reduceGroupsK` function, because otherwise it caused resolution ambiguity between Kotlin, Scala and Java APIs, which was quite hard to solve.
+We had to implement the functions `reduceGroups` and `reduce` for Kotlin separately as `reduceGroupsK` and `reduceK` respectively, because otherwise it caused resolution ambiguity between Kotlin, Scala and Java APIs, which was quite hard to solve.
 
 We have a special example of work with this function in the [Groups example](https://github.com/JetBrains/kotlin-spark-api/edit/main/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples/Group.kt).
 

--- a/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples/Main.kt
+++ b/examples/src/main/kotlin/org/jetbrains/kotlinx/spark/examples/Main.kt
@@ -48,8 +48,8 @@ object Main {
 //                .also { it.printSchema() }
             .map { (triple, pair) -> Five(triple.first, triple.second, triple.third, pair?.first, pair?.second) }
             .groupByKey { it.a }
-            .reduceGroups(ReduceFunction { v1, v2 -> v1.copy(a = v1.a + v2.a, b = v1.a + v2.a) })
-            .map { it._2 }
+            .reduceGroupsK { v1, v2 -> v1.copy(a = v1.a + v2.a, b = v1.a + v2.a) }
+            .map { it.second }
             .repartition(1)
             .withCached {
                 write()

--- a/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/2.4/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -217,6 +217,13 @@ inline fun <reified KEY, reified VALUE> KeyValueGroupedDataset<KEY, VALUE>.reduc
     reduceGroups(ReduceFunction(func))
         .map { t -> t._1 to t._2 }
 
+/**
+ * (Kotlin-specific)
+ * Reduces the elements of this Dataset using the specified binary function. The given `func`
+ * must be commutative and associative or the result may be non-deterministic.
+ */
+inline fun <reified T> Dataset<T>.reduceK(noinline func: (T, T) -> T): T =
+    reduce(ReduceFunction(func))
 
 @JvmName("takeKeysTuple2")
 inline fun <reified T1, T2> Dataset<Tuple2<T1, T2>>.takeKeys(): Dataset<T1> = map { it._1() }

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -478,9 +478,10 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(1, 2, 3), 1),
                     SomeClass(intArrayOf(4, 3, 2), 1),
                 )
-                    .groupByKey { it.b }
-                    .reduceGroupsK { v1, v2 -> v1 }
-                    .reduceK { v1, v2 -> v1 }
+                    .groupByKey { it: SomeClass -> it.b }
+                    .reduceGroupsK { v1: SomeClass, v2: SomeClass -> v1 }
+                    .filter { it: Pair<Int, SomeClass> -> true } // not sure why this does work, but reduce doesn't
+                    .reduceK { v1: Pair<Int, SomeClass>, v2: Pair<Int, SomeClass> -> v1 }
 
                 dataset.second.a shouldBe intArrayOf(1, 2, 3)
             }

--- a/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/2.4/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -457,7 +457,7 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(4, 3, 2), 1),
                 )
                     .groupByKey { it.b }
-                    .reduceGroupsK(func = { a, b -> SomeClass(a.a + b.a, a.b) })
+                    .reduceGroupsK { a, b -> SomeClass(a.a + b.a, a.b) }
                     .takeValues()
 
                 dataset.count() shouldBe 1
@@ -472,6 +472,17 @@ class ApiTest : ShouldSpec({
 
                 dataset.sort(SomeClass::a, SomeClass::b)
                 dataset.takeAsList(1).first().b shouldBe 2
+            }
+            should("Have Kotlin ready functions in place of overload ambiguity") {
+                val dataset: Pair<Int, SomeClass> = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 1),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                    .groupByKey { it.b }
+                    .reduceGroupsK { v1, v2 -> v1 }
+                    .reduceK { v1, v2 -> v1 }
+
+                dataset.second.a shouldBe intArrayOf(1, 2, 3)
             }
         }
     }

--- a/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
+++ b/kotlin-spark-api/3.0/src/main/kotlin/org/jetbrains/kotlinx/spark/api/ApiV1.kt
@@ -212,6 +212,13 @@ inline fun <reified KEY, reified VALUE> KeyValueGroupedDataset<KEY, VALUE>.reduc
     reduceGroups(ReduceFunction(func))
         .map { t -> t._1 to t._2 }
 
+/**
+ * (Kotlin-specific)
+ * Reduces the elements of this Dataset using the specified binary function. The given `func`
+ * must be commutative and associative or the result may be non-deterministic.
+ */
+inline fun <reified T> Dataset<T>.reduceK(noinline func: (T, T) -> T): T =
+    reduce(ReduceFunction(func))
 
 @JvmName("takeKeysTuple2")
 inline fun <reified T1, T2> Dataset<Tuple2<T1, T2>>.takeKeys(): Dataset<T1> = map { it._1() }

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -499,7 +499,7 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(4, 3, 2), 1),
                 )
                     .groupByKey { it.b }
-                    .reduceGroupsK(func = { a, b -> SomeClass(a.a + b.a, a.b) })
+                    .reduceGroupsK { a, b -> SomeClass(a.a + b.a, a.b) }
                     .takeValues()
 
                 dataset.count() shouldBe 1
@@ -514,6 +514,17 @@ class ApiTest : ShouldSpec({
 
                 dataset.sort(SomeClass::a, SomeClass::b)
                 dataset.takeAsList(1).first().b shouldBe 2
+            }
+            should("Have Kotlin ready functions in place of overload ambiguity") {
+                val dataset: Pair<Int, SomeClass> = dsOf(
+                    SomeClass(intArrayOf(1, 2, 3), 1),
+                    SomeClass(intArrayOf(4, 3, 2), 1),
+                )
+                    .groupByKey { it.b }
+                    .reduceGroupsK { v1, v2 -> v1 }
+                    .reduceK { v1, v2 -> v1 }
+
+                dataset.second.a shouldBe intArrayOf(1, 2, 3)
             }
         }
     }

--- a/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
+++ b/kotlin-spark-api/3.0/src/test/kotlin/org/jetbrains/kotlinx/spark/api/ApiTest.kt
@@ -520,9 +520,10 @@ class ApiTest : ShouldSpec({
                     SomeClass(intArrayOf(1, 2, 3), 1),
                     SomeClass(intArrayOf(4, 3, 2), 1),
                 )
-                    .groupByKey { it.b }
-                    .reduceGroupsK { v1, v2 -> v1 }
-                    .reduceK { v1, v2 -> v1 }
+                    .groupByKey { it: SomeClass -> it.b }
+                    .reduceGroupsK { v1: SomeClass, v2: SomeClass -> v1 }
+                    .filter { it: Pair<Int, SomeClass> -> true } // not sure why this does work, but reduce doesn't
+                    .reduceK { v1: Pair<Int, SomeClass>, v2: Pair<Int, SomeClass> -> v1 }
 
                 dataset.second.a shouldBe intArrayOf(1, 2, 3)
             }


### PR DESCRIPTION
This PR adds `Dataset.reduceK {}` to fix the overload resolution ambiguity.

Fixed example to use reduceGroupsK as well.

Added test specifically for overload resolution ambiguity stuff. I included `filter {}` in the test as well, since the only reason we don't have overload resolution ambiguity for that one is that the Scala type `T => Boolean` is resolved in Kotlin `(T) -> Any`. This looks like a bug in the Kotlin/Scala interop, so if this ever gets fixed, we'll need a `Dataset.filterK {}` as well unfortunately.
