### PR TITLE
fix: Perform fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kotlin for Apache® Spark™ [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx.spark/kotlin-spark-api-parent.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:org.jetbrains.kotlinx.spark%20AND%20v:1.0.1) [![official JetBrains project](http://jb.gg/badges/incubator.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
+# Kotlin for Apache® Spark™ [![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx.spark/kotlin-spark-api-parent.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:org.jetbrains.kotlinx.spark%20AND%20v:1.0.2) [![official JetBrains project](http://jb.gg/badges/incubator.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 
 
 Your next API to work with  [Apache Spark](https://spark.apache.org/). 
@@ -6,7 +6,7 @@ Your next API to work with  [Apache Spark](https://spark.apache.org/).
 This project adds a missing layer of compatibility between [Kotlin](https://kotlinlang.org/) and [Apache Spark](https://spark.apache.org/).
 It allows Kotlin developers to use familiar language features such as data classes, and lambda expressions as simple expressions in curly braces or method references. 
 
-We have opened a Spark Project Improvement Proposal: [Kotlin support for Apache Spark](http://issues.apache.org/jira/browse/SPARK-32530#) to work with the community towards getting Kotlin support as a first-class citizen in Apache Spark. We encourage you to voice your opinions and participate in the discussion.
+We have opened a Spark Project Improvement Proposal: [Kotlin support for Apache Spark](http://issues.apache.org/jira/browse/SPARK-32530) to work with the community towards getting Kotlin support as a first-class citizen in Apache Spark. We encourage you to voice your opinions and participate in the discussion.
 
 ## Table of Contents
 
@@ -41,7 +41,7 @@ The list of Kotlin for Apache Spark releases is available [here](https://github.
 The Kotlin for Spark artifacts adhere to the following convention:
 `[Apache Spark version]_[Scala core version]:[Kotlin for Apache Spark API version]` 
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx.spark/kotlin-spark-api-parent.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.jetbrains.kotlinx.spark%22%20AND%20a:%22kotlin-spark-api-3.0.0_2.12%22)
+[![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.kotlinx.spark/kotlin-spark-api-parent.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:"org.jetbrains.kotlinx.spark"%20AND%20a:"kotlin-spark-api-3.0")
 
 ## How to configure Kotlin for Apache Spark in your project
 
@@ -52,7 +52,7 @@ Here's an example `pom.xml`:
 ```xml
 <dependency>
   <groupId>org.jetbrains.kotlinx.spark</groupId>
-  <artifactId>kotlin-spark-api-3.0.0</artifactId>
+  <artifactId>kotlin-spark-api-3.0</artifactId>
   <version>${kotlin-spark-api.version}</version>
 </dependency>
 <dependency>


### PR DESCRIPTION
Hello! 👋

I have performed a few fixes in the documentation (`README.md`). See the list of changes below:
1. Correct artifact notation of the dependency in the pom.xml example (`kotlin-spark-api-3.0.0` → `kotlin-spark-api-3.0`)
2. Correct artifact notation of the dependency in the search query of Maven Central banner in 'Releases' section (`kotlin-spark-api-3.0.0` → `kotlin-spark-api-3.0`)
3. Correct version of artifact in Maven Central banner  (`1.0.1` → `1.0.2`)
4. Insignificant fixup in link to the issue 'SPARK-32530'